### PR TITLE
Call redistribute before calling increment.

### DIFF
--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -171,6 +171,7 @@ ROMSX::WritePlotFile (int which, Vector<std::string> plot_var_names)
         {
             MultiFab temp_dat(mf[lev].boxArray(), mf[lev].DistributionMap(), 1, 0);
             temp_dat.setVal(0);
+            tracer_particles->Redistribute();
             tracer_particles->Increment(temp_dat, lev);
             MultiFab::Copy(mf[lev], temp_dat, 0, mf_comp, 1, 0);
             mf_comp += 1;

--- a/Source/Particles/TerrainFittedPC.H
+++ b/Source/Particles/TerrainFittedPC.H
@@ -64,7 +64,7 @@ public:
     void AdvectWithUmac (amrex::MultiFab* umac, int level, amrex::Real dt,
                          const amrex::MultiFab& a_z_height);
 
-    void Increment (amrex::MultiFab& mf, int level);
+    //void Increment (amrex::MultiFab& mf, int level);
 };
 
 #endif

--- a/Source/Particles/TerrainFittedPC.H
+++ b/Source/Particles/TerrainFittedPC.H
@@ -63,8 +63,6 @@ public:
 
     void AdvectWithUmac (amrex::MultiFab* umac, int level, amrex::Real dt,
                          const amrex::MultiFab& a_z_height);
-
-    //void Increment (amrex::MultiFab& mf, int level);
 };
 
 #endif

--- a/Source/Particles/TerrainFittedPC.cpp
+++ b/Source/Particles/TerrainFittedPC.cpp
@@ -199,30 +199,3 @@ TerrainFittedPC::AdvectWithUmac (MultiFab* umac, int lev, Real dt, const MultiFa
 #endif
     }
 }
-
-/*
-  /brief Uses midpoint method to advance particles using umac.
-*/
-// void
-// TerrainFittedPC::Increment (MultiFab& mf, int lev)
-// {
-//     AMREX_ASSERT(OK());
-//     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
-
-//     const auto& geom = Geom(lev);
-//     const auto plo = geom.ProbLoArray();
-//     const auto dxi = geom.InvCellSizeArray();
-//     const auto domain = geom.Domain();
-//     amrex::ParticleToMesh(*this, mf, lev,
-//         [=] AMREX_GPU_DEVICE (const typename ParticleTileType::ConstParticleTileDataType& ptd, int ip,
-//                               amrex::Array4<amrex::Real> const& count)
-//         {
-//             const auto& p = make_particle<ConstParticleType>{}(ptd, ip);
-//             // auto iv = getParticleCell(p, plo, dxi, domain);
-//             IntVect iv(
-//                   AMREX_D_DECL(int(amrex::Math::floor((p.pos(0)-plo[0])*dxi[0])),
-//                                int(amrex::Math::floor((p.pos(1)-plo[1])*dxi[1])),
-//                                p.idata(0)));
-//             amrex::Gpu::Atomic::AddNoRet(&count(iv), 1.0_rt);
-//         }, false);
-// }

--- a/Source/Particles/TerrainFittedPC.cpp
+++ b/Source/Particles/TerrainFittedPC.cpp
@@ -203,26 +203,26 @@ TerrainFittedPC::AdvectWithUmac (MultiFab* umac, int lev, Real dt, const MultiFa
 /*
   /brief Uses midpoint method to advance particles using umac.
 */
-void
-TerrainFittedPC::Increment (MultiFab& mf, int lev)
-{
-    AMREX_ASSERT(OK());
-    AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
+// void
+// TerrainFittedPC::Increment (MultiFab& mf, int lev)
+// {
+//     AMREX_ASSERT(OK());
+//     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
 
-    const auto& geom = Geom(lev);
-    const auto plo = geom.ProbLoArray();
-    const auto dxi = geom.InvCellSizeArray();
-    const auto domain = geom.Domain();
-    amrex::ParticleToMesh(*this, mf, lev,
-        [=] AMREX_GPU_DEVICE (const typename ParticleTileType::ConstParticleTileDataType& ptd, int ip,
-                              amrex::Array4<amrex::Real> const& count)
-        {
-            const auto& p = make_particle<ConstParticleType>{}(ptd, ip);
-            // auto iv = getParticleCell(p, plo, dxi, domain);
-            IntVect iv(
-                  AMREX_D_DECL(int(amrex::Math::floor((p.pos(0)-plo[0])*dxi[0])),
-                               int(amrex::Math::floor((p.pos(1)-plo[1])*dxi[1])),
-                               p.idata(0)));
-            amrex::Gpu::Atomic::AddNoRet(&count(iv), 1.0_rt);
-        }, false);
-}
+//     const auto& geom = Geom(lev);
+//     const auto plo = geom.ProbLoArray();
+//     const auto dxi = geom.InvCellSizeArray();
+//     const auto domain = geom.Domain();
+//     amrex::ParticleToMesh(*this, mf, lev,
+//         [=] AMREX_GPU_DEVICE (const typename ParticleTileType::ConstParticleTileDataType& ptd, int ip,
+//                               amrex::Array4<amrex::Real> const& count)
+//         {
+//             const auto& p = make_particle<ConstParticleType>{}(ptd, ip);
+//             // auto iv = getParticleCell(p, plo, dxi, domain);
+//             IntVect iv(
+//                   AMREX_D_DECL(int(amrex::Math::floor((p.pos(0)-plo[0])*dxi[0])),
+//                                int(amrex::Math::floor((p.pos(1)-plo[1])*dxi[1])),
+//                                p.idata(0)));
+//             amrex::Gpu::Atomic::AddNoRet(&count(iv), 1.0_rt);
+//         }, false);
+// }


### PR DESCRIPTION
Also, once AMReX PR #3556 is merged, it will no longer be necessary to write your own Increment for ROMSX. 

AMReX PR #3556 should be merged before this.