### PR TITLE
Add parentheses around macro expressions

### DIFF
--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -1,5 +1,5 @@
-#ifndef _INDEX_DEFINES_H_
-#define _INDEX_DEFINES_H_
+#ifndef ROMSX_INDEX_DEFINES_H_
+#define ROMSX_INDEX_DEFINES_H_
 
 #include <AMReX_REAL.H>
 #include <AMReX_Arena.H>
@@ -18,10 +18,10 @@
 #endif
 
 // Cell-centered primitive variables
-#define PrimTheta_comp   Temp_comp -1
-#define PrimScalar_comp  RhoScalar_comp-1
+#define PrimTheta_comp   (Temp_comp -1)
+#define PrimScalar_comp  (RhoScalar_comp-1)
 
-#define NUM_PRIM         NVAR-1
+#define NUM_PRIM         (NVAR-1)
 #define NGROW          2
 
 namespace BCVars {

--- a/Source/ROMSX_Constants.H
+++ b/Source/ROMSX_Constants.H
@@ -1,5 +1,5 @@
-#ifndef _CONSTANTS_H_
-#define _CONSTANTS_H_
+#ifndef ROMSX_CONSTANTS_H_
+#define ROMSX_CONSTANTS_H_
 
 #include <AMReX_REAL.H>
 
@@ -15,9 +15,9 @@ constexpr amrex::Real PI = 3.14159265358979323846264338327950288;
 #define CONST_GRAV 9.81
 
 // Derived Constants
-#define ip_0    1./p_0
-#define iR_d    1./R_d
-#define iGamma  1./Gamma
-#define rdOcp   R_d/c_p
+#define ip_0    (1./p_0)
+#define iR_d    (1./R_d)
+#define iGamma  (1./Gamma)
+#define rdOcp   (R_d/c_p)
 
 #endif


### PR DESCRIPTION
Things like

    #define NUM_PRIM         NVAR-1

is error prone. For example, `N - NUM__PRIM` will become `N - NVAR - 1` instead of `N - (NVAR - 1)`.

Also note that names starting with `_[A-Z]` are reserved.