### PR TITLE
do InterpFromCoarseLevel instead of pcinterp_interp 

### DIFF
--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -395,6 +395,12 @@ REMORA::WritePlotFile ()
 
             // Do piecewise interpolation of mf into mf2
             for (int lev = 1; lev <= finest_level; ++lev) {
+                Interpolater* mapper_c = &pc_interp;
+                InterpFromCoarseLevel(mf2[lev], t_new[lev], mf[lev],
+                                      0, 0, mf2[lev].nComp(),
+                                      geom[lev], g2[lev],
+                                      null_bc_for_fill, 0, null_bc_for_fill, 0,
+                                      r2[lev-1], mapper_c, domain_bcs_type, 0);
                 for (MFIter mfi(mf2[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
                     const Box& bx = mfi.tilebox();
                     pcinterp_interp(bx,mf2[lev].array(mfi), 0, mf[lev].nComp(), mf[lev].const_array(mfi),0,r2[lev-1]);


### PR DESCRIPTION
when interpolating to a grid that's refined in the z direction