### PR TITLE
Remove omp for growntilebox type loops

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -3,3 +3,4 @@ inout
 parms
 ptd
 iput
+indx

--- a/Source/BoundaryConditions/REMORA_FillPatch.cpp
+++ b/Source/BoundaryConditions/REMORA_FillPatch.cpp
@@ -138,9 +138,6 @@ REMORA::FillPatch (int lev, Real time, MultiFab& mf_to_fill, Vector<MultiFab*> c
              (mf_box.ixType() == IndexType(IntVect(0,1,0))) )
         {
             int khi = geom[lev].Domain().bigEnd(2);
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
             for (MFIter mfi(mf_to_fill); mfi.isValid(); ++mfi)
             {
                 Box gbx  = mfi.growntilebox(); // Note this is face-centered since vel is

--- a/Source/BoundaryConditions/REMORA_FillPatcher.cpp
+++ b/Source/BoundaryConditions/REMORA_FillPatcher.cpp
@@ -162,9 +162,6 @@ void REMORAFillPatcher::BuildMask (BoxArray const& fba,
     com_ba.complementIn(com_bl, fba_bnd);
 
     // Fill mask based upon the com_bl BoxList
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*m_cf_mask); mfi.isValid(); ++mfi) {
         const Box& vbx = mfi.validbox();
         const Array4<int>& mask_arr = m_cf_mask->array(mfi);
@@ -235,9 +232,6 @@ void REMORAFillPatcher::InterpFace (MultiFab& fine,
         }
     }
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(fine); mfi.isValid(); ++mfi)
     {
         Box const& fbx = mfi.validbox();
@@ -341,9 +335,6 @@ void REMORAFillPatcher::InterpCell (MultiFab& fine,
     IndexType m_ixt = fine.boxArray().ixType();
     Box const& cdomain = amrex::convert(m_cgeom.Domain(), m_ixt);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(fine); mfi.isValid(); ++mfi) {
         Box const& fbx = mfi.validbox();
 

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -503,9 +503,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
 
     mask_arrays_for_write(lev, (Real) fill_value);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi) {
         auto bx = mfi.validbox();
         if (subdomain.contains(bx)) {
@@ -696,9 +693,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
     //requests.resize(0);
     //irq = 0;
     // Writing u (we loop over cons to get cell-centered box)
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi) {
         Box bx = mfi.validbox();
 
@@ -783,9 +777,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
     } // mfi
 
     // Writing v (we loop over cons to get cell-centered box)
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi) {
         Box bx = mfi.validbox();
 
@@ -873,9 +864,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
         } // in subdomain
     } // mfi
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi) {
         Box bx = mfi.validbox();
 

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -613,9 +613,6 @@ REMORA::WriteGenericPlotfileHeaderWithBathymetry (std::ostream &HeaderFile,
 
 void
 REMORA::mask_arrays_for_write(int lev, Real fill_value) {
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for (MFIter mfi(*cons_new[lev],false); mfi.isValid(); ++mfi) {
         Box bx = mfi.tilebox();
         Box gbx1 = mfi.growntilebox(IntVect(NGROW-1,NGROW-1,0));

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -78,9 +78,6 @@ REMORA::set_zeta_average (int lev)
 {
     std::unique_ptr<MultiFab>& mf_zeta = vec_zeta[lev];
     std::unique_ptr<MultiFab>& mf_Zt_avg1  = vec_Zt_avg1[lev];
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*cons_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         int nstp = 0;
@@ -112,9 +109,6 @@ REMORA::set_2darrays (int lev)
     std::unique_ptr<MultiFab>& mf_Hz  = vec_Hz[lev];
     int nstp = 0;
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*cons_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& ubar = (mf_ubar)->array(mfi);

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -100,9 +100,6 @@ REMORA::init_data_from_netcdf (int lev)
 #endif
     {
     // Don't tile this since we are operating on full FABs in this routine
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
     {
         // Define fabs for holding the initial data
@@ -144,9 +141,6 @@ REMORA::init_zeta_from_netcdf (int lev)
 #endif
         {
         // Don't tile this since we are operating on full FABs in this routine
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
         for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
         {
             FArrayBox &zeta_fab  = (*vec_zeta[lev])[mfi];
@@ -207,9 +201,6 @@ REMORA::init_bathymetry_from_netcdf (int lev)
 #endif
         {
         // Don't tile this since we are operating on full FABs in this routine
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
         for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
         {
             FArrayBox &h_fab     = (*vec_hOfTheConfusingName[lev])[mfi];
@@ -282,9 +273,6 @@ REMORA::init_bathymetry_from_netcdf (int lev)
     vec_xp[lev]->FillBoundary(geom[lev].periodicity());
     vec_yp[lev]->FillBoundary(geom[lev].periodicity());
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*vec_pm[lev]); mfi.isValid(); ++mfi )
     {
         Box bx   = mfi.tilebox();
@@ -356,9 +344,6 @@ REMORA::init_coriolis_from_netcdf (int lev)
 #endif
         {
         // Don't tile this since we are operating on full FABs in this routine
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
         for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
         {
             FArrayBox &fcor_fab  = (*vec_fcor[lev])[mfi];
@@ -400,9 +385,6 @@ REMORA::init_masks_from_netcdf (int lev)
 #endif
         {
         // Don't tile this since we are operating on full FABs in this routine
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
         for ( MFIter mfi(*cons_new[lev], false); mfi.isValid(); ++mfi )
         {
             FArrayBox &mskr_fab  = (*vec_mskr[lev])[mfi];

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -552,9 +552,6 @@ REMORA::set_pm_pn (int lev)
     vec_pm[lev]->setVal(dxi[0]); vec_pm[lev]->FillBoundary(geom[lev].periodicity());
     vec_pn[lev]->setVal(dxi[1]); vec_pn[lev]->FillBoundary(geom[lev].periodicity());
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*vec_xr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& xr = vec_xr[lev]->array(mfi);
@@ -601,9 +598,6 @@ REMORA::set_zeta_to_Ztavg (int lev)
 {
     std::unique_ptr<MultiFab>& mf_zeta = vec_zeta[lev];
     std::unique_ptr<MultiFab>& mf_Zt_avg1  = vec_Zt_avg1[lev];
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*vec_zeta[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<const Real> const& Zt_avg1 = (mf_Zt_avg1)->const_array(mfi);
@@ -622,9 +616,6 @@ REMORA::set_zeta_to_Ztavg (int lev)
 void
 REMORA::update_mskp (int lev)
 {
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*vec_mskr[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);

--- a/Source/TimeIntegration/REMORA_advance_2d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_2d.cpp
@@ -105,9 +105,6 @@ REMORA::advance_2d (int lev,
     MultiFab mf_DUon(convert(ba,IntVect(1,0,0)),dm,1,IntVect(NGROW,NGROW,0));
     MultiFab mf_DVom(convert(ba,IntVect(0,1,0)),dm,1,IntVect(NGROW,NGROW,0));
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*mf_rhoS, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real      > const& ubar = mf_ubar->array(mfi);
@@ -173,9 +170,6 @@ REMORA::advance_2d (int lev,
     mf_DUon.FillBoundary(geom[lev].periodicity());
     mf_DVom.FillBoundary(geom[lev].periodicity());
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*mf_rhoS, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real const> const& rhoS = mf_rhoS->const_array(mfi);

--- a/Source/TimeIntegration/REMORA_advance_3d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_3d.cpp
@@ -50,9 +50,6 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
     MultiFab mf_DC (ba,dm,1,IntVect(NGROW,NGROW,NGROW-1)); //2d missing j coordinate
     MultiFab mf_Hzk(ba,dm,1,IntVect(NGROW,NGROW,NGROW-1)); //2d missing j coordinate
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real      > const& u = mf_u.array(mfi);
@@ -166,9 +163,6 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
         }
 #endif
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real      > const& u = mf_u.array(mfi);
@@ -235,9 +229,6 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
 
     MultiFab mf_W(convert(ba,IntVect(0,0,1)),dm,1,IntVect(NGROW+1,NGROW+1,0));
     mf_W.setVal(0.0_rt);
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& Huon = mf_Huon->array(mfi);
@@ -312,9 +303,6 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
     }
     nnew = 0;
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& Hz  = mf_Hz->array(mfi);
@@ -361,9 +349,6 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
 
     FillPatch(lev, t_old[lev], mf_cons, cons_new, BCVars::cons_bc, BdyVars::t,0,true,false,0,0,dt_lev,*cons_old[lev]);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& AK = mf_AK.array(mfi);

--- a/Source/TimeIntegration/REMORA_gls.cpp
+++ b/Source/TimeIntegration/REMORA_gls.cpp
@@ -9,9 +9,6 @@ REMORA::gls_prestep (int lev, MultiFab* mf_gls, MultiFab* mf_tke,
                      const int iic, const int ntfirst, const int N, const Real dt_lev)
 {
     // temps: grad, gradL, XF, FX, FXL, EF, FE, FEL
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*mf_gls, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         Array4<Real> const& gls = mf_gls->array(mfi);
         Array4<Real> const& tke = mf_tke->array(mfi);
@@ -387,9 +384,6 @@ REMORA::gls_corrector (int lev, MultiFab* mf_gls, MultiFab* mf_tke,
     bool is_periodic_in_y = geomdata.isPeriodic(1);
 
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*mf_gls, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Box   bx = mfi.tilebox();
@@ -440,9 +434,6 @@ REMORA::gls_corrector (int lev, MultiFab* mf_gls, MultiFab* mf_tke,
     (*physbcs[lev])(mf_shear2_cached,*mf_mskr,0,1,mf_shear2_cached.nGrowVect(),t_new[lev],BCVars::foextrap_bc);
     mf_CF.setVal(0.0_rt);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*mf_gls, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Box  bx = mfi.tilebox();

--- a/Source/TimeIntegration/REMORA_prestep.cpp
+++ b/Source/TimeIntegration/REMORA_prestep.cpp
@@ -69,9 +69,6 @@ REMORA::prestep (int lev,
     MultiFab::Copy(mf_saltcache,S_new,Salt_comp,0,1,IntVect(NGROW,NGROW,0));
     MultiFab::Copy(mf_tempcache,S_new,Temp_comp,0,1,IntVect(NGROW,NGROW,0));
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real> const& DC = mf_DC.array(mfi);

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -112,9 +112,6 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
     auto N = Geom(lev).Domain().size()[2]-1; // Number of vertical "levs" aka, NZ
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real const> const& rdrag = mf_rdrag->const_array(mfi);
@@ -142,9 +139,6 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
     FillPatch(lev, time, *vec_bustr[lev].get(), GetVecOfPtrs(vec_bustr), BCVars::u2d_simple_bc, BdyVars::null,0,true,false);
     FillPatch(lev, time, *vec_bvstr[lev].get(), GetVecOfPtrs(vec_bvstr), BCVars::v2d_simple_bc, BdyVars::null,0,true,false);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real const> const& h     = vec_hOfTheConfusingName[lev]->const_array(mfi);
@@ -232,9 +226,6 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
     mf_W.FillBoundary(geom[lev].periodicity());
     (*physbcs[lev])(mf_W,*mf_mskr.get(),0,1,mf_W.nGrowVect(),t_new[lev],BCVars::zvel_bc);
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(S_old, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         Array4<Real const> const& Hz    = vec_Hz[lev]->const_array(mfi);

--- a/Source/Utils/REMORA_DepthStretchTransform.H
+++ b/Source/Utils/REMORA_DepthStretchTransform.H
@@ -21,9 +21,6 @@ REMORA::stretch_transform (int lev)
     std::unique_ptr<MultiFab>& mf_z_phys_nd  = vec_z_phys_nd[lev];
     auto N_loop = Geom(lev).Domain().size()[2]; // Number of vertical "levs" aka, NZ
 
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*cons_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
       Array4<Real> const& z_w = (mf_z_w)->array(mfi);
@@ -204,9 +201,6 @@ REMORA::stretch_transform (int lev)
     vec_Hz[lev]->FillBoundary(geom[lev].periodicity());
 
     // Define nodal z as average of z on w-faces
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
     for ( MFIter mfi(*cons_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
       Array4<Real> const& z_w = (mf_z_w)->array(mfi);


### PR DESCRIPTION
Removes `pragma omp parallel` statements from MFIter loops which may have overlapping tiles for sanity-checking

https://ccse.lbl.gov/pub/RegressionTesting1/REMORA/2025-01-21-002/index.html