### PR TITLE
Add remora_api library as an install target

### DIFF
--- a/Build/cmake.sh
+++ b/Build/cmake.sh
@@ -12,4 +12,4 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
       -DREMORA_ENABLE_FCOMPARE:BOOL=ON \
       -DREMORA_ENABLE_DOCUMENTATION:BOOL=OFF \
       -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
-      .. && make -j8
+      .. && make -j8 && make install

--- a/Build/cmake_with_netcdf.sh
+++ b/Build/cmake_with_netcdf.sh
@@ -29,4 +29,4 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
       -DREMORA_ENABLE_NETCDF:BOOL=ON \
       -DREMORA_ENABLE_HDF5:BOOL=ON \
       -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
-      .. && make -j8
+      .. && make -j8 && make install

--- a/Build/cmake_with_particles.sh
+++ b/Build/cmake_with_particles.sh
@@ -15,4 +15,4 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
       -DREMORA_ENABLE_DOCUMENTATION:BOOL=OFF \
       -DREMORA_ENABLE_PARTICLES:BOOL=ON \
       -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
-      .. && make -j8
+      .. && make -j8 && make install

--- a/CMake/BuildREMORAExe.cmake
+++ b/CMake/BuildREMORAExe.cmake
@@ -21,7 +21,7 @@ function(build_remora_lib remora_lib_name)
                    ${SRC_DIR}/Particles/REMORA_PC_Init.cpp
                    ${SRC_DIR}/Particles/REMORA_PC_Utils.cpp
                    ${SRC_DIR}/Particles/REMORA_Tracers.cpp)
-    target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/Particles)
+    target_include_directories(${remora_lib_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/Particles>)
     target_compile_definitions(${remora_lib_name} PUBLIC REMORA_USE_PARTICLES)
   endif()
 
@@ -120,7 +120,7 @@ function(build_remora_lib remora_lib_name)
 
   include(AMReXBuildInfo)
   generate_buildinfo(${remora_lib_name} ${CMAKE_SOURCE_DIR})
-  target_include_directories(${remora_lib_name} PUBLIC ${AMREX_SUBMOD_LOCATION}/Tools/C_scripts)
+    target_include_directories(${remora_lib_name} PUBLIC $<BUILD_INTERFACE:${AMREX_SUBMOD_LOCATION}/Tools/C_scripts>)
 
   if(REMORA_ENABLE_PNETCDF)
     if(PNETCDF_FOUND)
@@ -143,13 +143,13 @@ function(build_remora_lib remora_lib_name)
   endif()
 
   #REMORA include directories
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR})
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/BoundaryConditions)
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/Initialization)
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/Utils)
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/TimeIntegration)
-  target_include_directories(${remora_lib_name} PUBLIC ${SRC_DIR}/IO)
-  target_include_directories(${remora_lib_name} PUBLIC ${CMAKE_BINARY_DIR})
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/BoundaryConditions>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/Initialization>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/Utils>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/TimeIntegration>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Source/IO>)
+  target_include_directories(${remora_lib_name} PUBLIC  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>)
 
   #Link to amrex library
   target_link_libraries_system(${remora_lib_name} PUBLIC amrex)

--- a/CMake/REMORAConfig.cmake.in
+++ b/CMake/REMORAConfig.cmake.in
@@ -1,0 +1,18 @@
+@PACKAGE_INIT@
+
+find_package(AMReX QUIET REQUIRED @AMREX_COMPONENTS@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+set(@PROJECT_NAME@_INCLUDE_DIRS "${PROJECT_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+set(@PROJECT_NAME@_LIBRARY_DIRS "${PROJECT_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+set(@PROJECT_NAME@_LIBRARIES "@PROJECT_NAME@::remora_srclib")
+
+# CMake targets aliases: last dimension built will be our legacy target
+# protection in case of multiple inclusions
+if( NOT TARGET @PROJECT_NAME@::remora_api)
+    add_library(@PROJECT_NAME@::remora_api ALIAS remora_srclib)
+endif()
+
+set(@PROJECT_NAME@_FOUND TRUE)
+check_required_components(@PROJECT_NAME@)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,3 +119,57 @@ endif()
 if(REMORA_ENABLE_DOCUMENTATION)
    add_subdirectory(Docs)
 endif()
+
+# Installation rules
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+# Create non-object library for use as external target
+add_library(remora_api)
+if (BUILD_SHARED_LIBS)
+  set_target_properties(remora_api PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+if (REMORA_ENABLE_CUDA)
+   setup_target_for_cuda_compilation(remora_api)
+endif ()
+target_link_libraries(remora_api PUBLIC remora_srclib)
+add_library(${PROJECT_NAME}::remora_api ALIAS remora_srclib)
+
+# Collect all headers and make them installable with the target
+file(GLOB_RECURSE REMORA_INCLUDES "${CMAKE_SOURCE_DIR}/Source/*.H")
+
+set_target_properties(
+  remora_srclib PROPERTIES PUBLIC_HEADER "${REMORA_INCLUDES}")
+
+# Install ERF
+install(
+  TARGETS remora_api remora_srclib
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME       DESTINATION bin
+  ARCHIVE       DESTINATION lib
+  LIBRARY       DESTINATION lib
+  INCLUDES      DESTINATION include
+  PUBLIC_HEADER DESTINATION include
+  )
+
+# Install all headers in include directories
+#install(
+#  DIRECTORY ${REMORA_INCLUDE_DIRECTORIES}
+#  DESTINATION include
+#  FILES_MATCHING PATTERN "*.H")
+
+# Make ERF discoverable using `find_package`
+install(
+  EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  )
+configure_package_config_file(
+  CMake/${PROJECT_NAME}Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  )
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  )


### PR DESCRIPTION
* Minor updates to include directories for superbuild
* Added install target
* Added REMORAConfig.cmake generation

This is based on changes to ERF from https://github.com/erf-model/ERF/pull/1833 and https://github.com/erf-model/ERF/pull/2347

This was tested with:
```bash
cd Build
./cmake.sh
```

**Installation Output:**

The build process creates the following files:

**Libraries** (in `install/lib/`):
- `libamrex.a`
- `libamrex_3d.a` 
- `libremora_api.a`

**CMake Config Files** (in `install/lib/cmake/REMORA/`):
- `REMORAConfig.cmake`
- `REMORATargets-release.cmake`
- `REMORATargets.cmake`

**Note:** For applications that prefer shared libraries for linking, you can use the `BUILD_SHARED_LIBS` option.

**Future Work:**
The install step (`cmake --install build`) is not yet added to the CI scripts - this can be addressed in a separate PR.