### PR TITLE
Fix warnings, CI configuration, and shared library builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
         export CCACHE_MAXSIZE=600M
         ccache -z
 
-        cmake --build ${{runner.workspace}}/REMORA/build-${{matrix.os}} --parallel ${{env.NPROCS}};
+        cmake \
+          --build ${{runner.workspace}}/REMORA/build-${{matrix.os}} \
+          --parallel ${{env.NPROCS}} \
+          2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -56,7 +56,8 @@ jobs:
             -DREMORA_DIM:STRING=3 \
             -DREMORA_ENABLE_MPI:BOOL=OFF \
             -DREMORA_ENABLE_CUDA:BOOL=ON .
-          cmake --build build-${{matrix.cuda_pkg}} -- -j $(nproc)
+          cmake --build build-${{matrix.cuda_pkg}} --parallel $(nproc) \
+          2>&1 | tee -a ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output.txt;
 
           ccache -s
           du -hs ~/.cache/ccache

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -52,6 +52,10 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+    - name: Compile and Link
+      run: |
+        cmake --build ${{runner.workspace}}/REMORA/build --parallel 2 --verbose 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
+
     - name: Report
       run: |
         egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
@@ -60,10 +64,6 @@ jobs:
         cat ${{runner.workspace}}/build-output-warnings.txt
         export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
         exit ${return}
-
-    - name: Compile and Link
-      run: |
-        cmake --build ${{runner.workspace}}/REMORA/build --parallel 2 --verbose
 
     - name: CMake Tests # see file REMORA/Tests/CTestList.cmake
       run: |

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -86,7 +86,7 @@ jobs:
 
         pushd ${{runner.workspace}}/REMORA/build-${{matrix.os}};
         # make -j ${{env.NPROCS}};
-        make -j 2;
+        make -j 2 2>&1 | tee -a ${{runner.workspace}}/build-${{matrix.os}}-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,7 @@ jobs:
         export CCACHE_SLOPPINESS=time_macros
         ccache -z
 
-        cmake --build ${{runner.workspace}}/REMORA/build --parallel 2 --verbose
+        cmake --build ${{runner.workspace}}/REMORA/build --parallel 2 --verbose 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         du -hs ~/Library/Caches/ccache
         ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         cmake \
           -B${{runner.workspace}}/REMORA/build \
-          -DBUILD_SHARED_LIBS:BOOL=TRUE \
+          -DBUILD_SHARED_LIBS:BOOL=FALSE \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
           -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -58,7 +58,7 @@ jobs:
           -DCMAKE_C_COMPILER=$(which icx) \
           -DCMAKE_CXX_COMPILER=$(which icpx) \
           -DCMAKE_CXX_STANDARD=17
-        make -j 2
+        make -j 2 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/Exec/Advection/prob.cpp
+++ b/Exec/Advection/prob.cpp
@@ -129,25 +129,25 @@ void Problem::init_analytic_prob(
         // Construct a box that is on x-faces
         const Box& xbx = surroundingNodes(bx,0);
         // Set the x-velocity
-        ParallelFor(xbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx, [=, parms_gpu=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-              x_vel(i, j, k) = parms.u_0;
+              x_vel(i, j, k) = parms_gpu.u_0;
         });
 
         // Construct a box that is on y-faces
         const Box& ybx = surroundingNodes(bx,1);
 
         // Set the y-velocity
-        ParallelFor(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=, parms_gpu=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-              y_vel(i, j, k) = parms.v_0;
+              y_vel(i, j, k) = parms_gpu.v_0;
         });
 
         // Construct a box that is on z-faces
         const Box& zbx = surroundingNodes(bx,2);
 
         // Set the z-velocity
-        ParallelFor(zbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             z_vel(i, j, k) = 0.0;
         });

--- a/Exec/Advection/prob.cpp
+++ b/Exec/Advection/prob.cpp
@@ -29,9 +29,9 @@ Problem::Problem(const amrex::Real* /*problo*/, const amrex::Real* /*probhi*/)
  * \brief Initializes bathymetry h and surface height Zeta
  */
 void Problem::init_analytic_bathymetry (
-        int lev, const amrex::Geometry& geom,
-        SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        int /*lev*/, const amrex::Geometry& geom,
+        SolverChoice const& /*m_solverChoice*/,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_h)
 {
     const auto & geomdata = geom.data();
@@ -66,10 +66,10 @@ void Problem::init_analytic_zeta (
 }
 
 void Problem::init_analytic_prob(
-        int lev,
+        int /*lev*/,
         const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
         amrex::MultiFab& mf_yvel,

--- a/Exec/Advection/prob.cpp
+++ b/Exec/Advection/prob.cpp
@@ -113,7 +113,7 @@ void Problem::init_analytic_prob(
             const Real rad = 0.1 * (prob_hi[0]-prob_lo[0]);
             const Real radsq = rad*rad;
             const Real rad_inner = 0.05 * (prob_hi[0]-prob_lo[0]);
-            const Real rad_inner_sq = rad_inner*rad_inner;
+            [[maybe_unused]] const Real rad_inner_sq = rad_inner*rad_inner;
 
             if (l_use_salt) {
                 state(i,j,k,Salt_comp)= S0;

--- a/Exec/BoundaryLayer/prob.H
+++ b/Exec/BoundaryLayer/prob.H
@@ -64,7 +64,7 @@ public:
         amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind);
 
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 
 #endif

--- a/Exec/BoundaryLayer/prob.cpp
+++ b/Exec/BoundaryLayer/prob.cpp
@@ -35,14 +35,14 @@ void Problem::init_analytic_bathymetry (
 
     mf_h.setVal(geomdata.ProbHi(2));
 
-    const int Lm = geomdata.Domain().size()[0];
-    const int Mm = geomdata.Domain().size()[1];
+    [[maybe_unused]] const int Lm = geomdata.Domain().size()[0];
+    [[maybe_unused]] const int Mm = geomdata.Domain().size()[1];
 
     for ( MFIter mfi(mf_h, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
       Array4<Real> const& h  = (mf_h).array(mfi);
       Array4<const Real> const& xr  = remora.vec_xr[lev]->array(mfi);
-      Array4<const Real> const& yr  = remora.vec_yr[lev]->array(mfi);
+      [[maybe_unused]] Array4<const Real> const& yr  = remora.vec_yr[lev]->array(mfi);
 
       Box bx = mfi.tilebox();
       Box gbx2 = bx;
@@ -114,7 +114,7 @@ void Problem::init_analytic_prob(
         amrex::MultiFab& mf_yvel,
         amrex::MultiFab& mf_zvel)
 {
-    bool l_use_salt = m_solverChoice.use_salt;
+    [[maybe_unused]] bool l_use_salt = m_solverChoice.use_salt;
     auto T0 = m_solverChoice.T0;
     auto S0 = m_solverChoice.S0;
 
@@ -122,8 +122,8 @@ void Problem::init_analytic_prob(
 
     const int khi = geomdata.Domain().bigEnd()[2];
 
-    bool EWPeriodic = geomdata.isPeriodic(0);
-    bool NSPeriodic = geomdata.isPeriodic(1);
+    [[maybe_unused]] bool EWPeriodic = geomdata.isPeriodic(0);
+    [[maybe_unused]] bool NSPeriodic = geomdata.isPeriodic(1);
 
     for (MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {

--- a/Exec/BoundaryLayer/prob.cpp
+++ b/Exec/BoundaryLayer/prob.cpp
@@ -64,8 +64,8 @@ void Problem::init_analytic_bathymetry (
 
 void Problem::init_analytic_grid_scale (
         int /*lev*/, const amrex::Geometry& geom,
-        SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        SolverChoice const& /*m_solverChoice*/,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_pm, amrex::MultiFab& mf_pn)
 {
     auto geomdata = geom.data();

--- a/Exec/CMakeLists.txt
+++ b/Exec/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(remora_lib_name remora_srclib)
 add_library(${remora_lib_name} OBJECT)
+if (BUILD_SHARED_LIBS)
+  set_target_properties(${remora_lib_name} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 include(${CMAKE_SOURCE_DIR}/CMake/BuildREMORAExe.cmake)
 build_remora_lib(${remora_lib_name})
 add_subdirectory(Seamount)

--- a/Exec/Channel_Test/prob.H
+++ b/Exec/Channel_Test/prob.H
@@ -57,7 +57,7 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 
 #endif

--- a/Exec/Channel_Test/prob.cpp
+++ b/Exec/Channel_Test/prob.cpp
@@ -20,9 +20,9 @@ amrex_probinit(const amrex_real* problo, const amrex_real* probhi)
  * \brief Initializes bathymetry h and surface height Zeta
  */
 void Problem::init_analytic_bathymetry (
-        int lev, const amrex::Geometry& geom,
+        int /*lev*/, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_h)
 {
     auto geomdata = geom.data();
@@ -47,7 +47,7 @@ void Problem::init_analytic_bathymetry (
 
         Gpu::streamSynchronize();
 
-        ParallelForRNG(bxD, [=] AMREX_GPU_DEVICE (int i, int j, int , auto engine)
+        ParallelForRNG(bxD, [=] AMREX_GPU_DEVICE (int i, int j, int , auto /*engine*/)
         {
             h(i,j,0) = 50.0_rt;
         });

--- a/Exec/Channel_Test/prob.cpp
+++ b/Exec/Channel_Test/prob.cpp
@@ -82,8 +82,8 @@ void Problem::init_analytic_prob(
     auto geomdata = geom.data();
     const int khi = geomdata.Domain().bigEnd()[2];
 
-    bool EWPeriodic = geomdata.isPeriodic(1);
-    bool NSPeriodic = geomdata.isPeriodic(0);
+    [[maybe_unused]] bool EWPeriodic = geomdata.isPeriodic(1);
+    [[maybe_unused]] bool NSPeriodic = geomdata.isPeriodic(0);
 
     auto T0 = m_solverChoice.T0;
     auto S0 = m_solverChoice.S0;
@@ -109,9 +109,9 @@ void Problem::init_analytic_prob(
 
             // Create bounding box for x and y to make spatially-dependent T and S
             const Real xcent = 0.5*(prob_lo[0] + prob_hi[0]);
-            const Real ycent = 0.5*(prob_lo[1] + prob_hi[1]);
+            [[maybe_unused]] const Real ycent = 0.5*(prob_lo[1] + prob_hi[1]);
 
-            const Real x  = prob_lo[0] + (i + 0.5) * dx[0] - xcent;
+            [[maybe_unused]] const Real x  = prob_lo[0] + (i + 0.5) * dx[0] - xcent;
             const Real y  = prob_lo[1] + (j + 0.5) * dx[1];
 
             state(i,j,k,Temp_comp)=T0 + z / (9.8_rt * 1.7_rt);
@@ -134,8 +134,8 @@ void Problem::init_analytic_prob(
             const auto prob_hi         = geomdata.ProbHi();
             const auto dx              = geomdata.CellSize();
 
-            const Real xcent = 0.5*(prob_lo[0] + prob_hi[0]);
-            const Real ycent = 0.5*(prob_lo[1] + prob_hi[1]);
+            [[maybe_unused]] const Real xcent = 0.5*(prob_lo[0] + prob_hi[0]);
+            [[maybe_unused]] const Real ycent = 0.5*(prob_lo[1] + prob_hi[1]);
 
             const Real z = z_r(i,j,k);
             // h(i,j,0) = -geomdata.ProbLo(2);
@@ -228,8 +228,8 @@ void Problem::init_analytic_smflux(
         MultiFab& mf_sustr, MultiFab& mf_svstr)
 {
     auto geomdata = geom.data();
-    bool EWPeriodic = geomdata.isPeriodic(0);
-    bool NSPeriodic = geomdata.isPeriodic(1);
+    [[maybe_unused]] bool EWPeriodic = geomdata.isPeriodic(0);
+    [[maybe_unused]] bool NSPeriodic = geomdata.isPeriodic(1);
 
     Real time = remora.get_t_old(lev);
 

--- a/Exec/DogboneAnalytic/prob.cpp
+++ b/Exec/DogboneAnalytic/prob.cpp
@@ -118,7 +118,7 @@ void Problem::init_analytic_prob(
         } else {
             ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real x = x_r(i,j,0);
+                [[maybe_unused]] const Real x = x_r(i,j,0);
 
                 if (l_use_salt) {
                     state(i, j, k, Salt_comp) = 10.0_rt - 10.0_rt * (x_r(i,j,0) - 8400.0_rt) / 8400.0_rt;

--- a/Exec/DoubleGyre/prob.H
+++ b/Exec/DoubleGyre/prob.H
@@ -57,7 +57,7 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 
 #endif

--- a/Exec/DoubleGyre/prob.cpp
+++ b/Exec/DoubleGyre/prob.cpp
@@ -118,10 +118,10 @@ void Problem::init_analytic_prob(
 }
 
 void Problem::init_analytic_vmix(
-        int lev,
+        int /*lev*/,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         MultiFab& mf_Akv, MultiFab& mf_Akt)
 {
     for ( MFIter mfi((mf_Akv), TilingIfNotGPU()); mfi.isValid(); ++mfi )
@@ -202,7 +202,7 @@ void Problem::init_analytic_smflux(
         const Box& xbx2 = mfi.grownnodaltilebox(0, IntVect(NGROW,NGROW,0));
 
         Array4<Real> const& sustr = mf_sustr.array(mfi);
-        ParallelFor(xbx2, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx2, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             // Create bounding box for x and y to make spatially-dependent T and S
             const auto prob_lo         = geomdata.ProbLo();

--- a/Exec/DoubleGyre/prob.cpp
+++ b/Exec/DoubleGyre/prob.cpp
@@ -183,8 +183,8 @@ void Problem::init_analytic_smflux(
         MultiFab& mf_sustr, MultiFab& mf_svstr)
 {
     auto geomdata = geom.data();
-    bool EWPeriodic = geomdata.isPeriodic(0);
-    bool NSPeriodic = geomdata.isPeriodic(1);
+    [[maybe_unused]] bool EWPeriodic = geomdata.isPeriodic(0);
+    [[maybe_unused]] bool NSPeriodic = geomdata.isPeriodic(1);
 
     const auto prob_lo         = geomdata.ProbLo();
     const auto prob_hi         = geomdata.ProbHi();
@@ -198,7 +198,7 @@ void Problem::init_analytic_smflux(
     for ( MFIter mfi((mf_sustr), TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
         const Box& bx = mfi.tilebox();
-        const Box& xbx = surroundingNodes(bx,0);
+        [[maybe_unused]] const Box& xbx = surroundingNodes(bx,0);
         const Box& xbx2 = mfi.grownnodaltilebox(0, IntVect(NGROW,NGROW,0));
 
         Array4<Real> const& sustr = mf_sustr.array(mfi);

--- a/Exec/DoublyPeriodic/prob.cpp
+++ b/Exec/DoublyPeriodic/prob.cpp
@@ -66,7 +66,8 @@ void Problem::init_analytic_bathymetry (
           amrex::ParallelFor(gbx2D,
           [=] AMREX_GPU_DEVICE (int i, int j, int )
           {
-              Real val1, val2;
+              Real val1;
+              [[maybe_unused]] Real val2;
               int iFort = i+1;
               int jFort = j+1;
               if (NSPeriodic) {

--- a/Exec/DoublyPeriodic/prob.cpp
+++ b/Exec/DoublyPeriodic/prob.cpp
@@ -206,7 +206,7 @@ void Problem::init_analytic_prob(
         const Box& zbx = surroundingNodes(bx,2);
 
         // Set the z-velocity
-        ParallelFor(zbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             z_vel(i, j, k) = 0.0_rt;
         });

--- a/Exec/DoublyPeriodic/prob.cpp
+++ b/Exec/DoublyPeriodic/prob.cpp
@@ -173,7 +173,7 @@ void Problem::init_analytic_prob(
         // Construct a box that is on x-faces
         const Box& xbx = surroundingNodes(bx,0);
         // Set the x-velocity
-        ParallelFor(xbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx, [=, parms_gpu=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               // const auto prob_lo         = geomdata.ProbLo();
               // const auto dx              = geomdata.CellSize();
@@ -183,23 +183,23 @@ void Problem::init_analytic_prob(
               const Real z = -z_r(i,j,k);
 
               // Set the x-velocity
-              x_vel(i, j, k) = parms.u_0 + parms.uRef *
-                               std::log((z + parms.z0)/parms.z0)/
-                               std::log((parms.zRef +parms.z0)/parms.z0);
+              x_vel(i, j, k) = parms_gpu.u_0 + parms_gpu.uRef *
+                               std::log((z + parms_gpu.z0)/parms_gpu.z0)/
+                               std::log((parms_gpu.zRef +parms_gpu.z0)/parms_gpu.z0);
         });
 
         // Construct a box that is on y-faces
         const Box& ybx = surroundingNodes(bx,1);
 
         // Set the y-velocity
-        ParallelFor(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=, parms_gpu=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               //const auto prob_lo         = geomdata.ProbLo();
               //const auto dx              = geomdata.CellSize();
 
               // const Real x = prob_lo[0] + (i + 0.5) * dx[0];
               // const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-              y_vel(i, j, k) = parms.v_0;
+              y_vel(i, j, k) = parms_gpu.v_0;
         });
 
         // Construct a box that is on z-faces

--- a/Exec/DoublyPeriodic/prob.cpp
+++ b/Exec/DoublyPeriodic/prob.cpp
@@ -32,9 +32,9 @@ Problem::Problem(const amrex::Real* /*problo*/, const amrex::Real* /*probhi*/)
  * \brief Initializes bathymetry h and surface height Zeta
  */
 void Problem::init_analytic_bathymetry (
-        int lev, const amrex::Geometry& geom,
+        int /*lev*/, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_h)
 {
     //std::unique_ptr<MultiFab>& mf_z_w = vec_z_w[lev];

--- a/Exec/IdealMiniGrid/prob.H
+++ b/Exec/IdealMiniGrid/prob.H
@@ -37,7 +37,7 @@ public:
         amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
 
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 extern ProbParm parms;
 

--- a/Exec/ParticlesOverSeaMount/prob.cpp
+++ b/Exec/ParticlesOverSeaMount/prob.cpp
@@ -133,7 +133,7 @@ void Problem::init_analytic_prob(
 
         Real S0 = m_solverChoice.S0;
         Real T0 = m_solverChoice.T0;
-        ParallelFor(bx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // Geometry (note we must include these here to get the data on device)
             // const auto prob_lo         = geomdata.ProbLo();
@@ -177,7 +177,7 @@ void Problem::init_analytic_prob(
         const Box& ybx = surroundingNodes(bx,1);
 
         // Set the y-velocity
-        ParallelFor(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               // const auto prob_lo         = geomdata.ProbLo();
               // const auto dx              = geomdata.CellSize();
@@ -191,7 +191,7 @@ void Problem::init_analytic_prob(
         const Box& zbx = surroundingNodes(bx,2);
 
         // Set the z-velocity
-        ParallelFor(zbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             z_vel(i, j, k) = 0.0_rt;
         });

--- a/Exec/Seamount/prob.H
+++ b/Exec/Seamount/prob.H
@@ -59,7 +59,7 @@ public:
         amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
 
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 
 #endif

--- a/Exec/Seamount/prob.cpp
+++ b/Exec/Seamount/prob.cpp
@@ -23,9 +23,9 @@ Problem::Problem(const amrex::Real* /*problo*/, const amrex::Real* /*probhi*/)
  * \brief Initializes bathymetry h and surface height Zeta
  */
 void Problem::init_analytic_bathymetry (
-        int lev, const amrex::Geometry& geom,
+        int /*lev*/, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_h)
 {
     mf_h.setVal(geom.ProbHi(2));
@@ -164,10 +164,10 @@ void Problem::init_analytic_prob(
 }
 
 void Problem::init_analytic_vmix(
-        int lev,
+        int /*lev*/,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         MultiFab& mf_Akv, MultiFab& mf_Akt)
 {
     for ( MFIter mfi((mf_Akv), TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Exec/Seamount/prob.cpp
+++ b/Exec/Seamount/prob.cpp
@@ -136,7 +136,7 @@ void Problem::init_analytic_prob(
         // Construct a box that is on x-faces
         const Box& xbx = surroundingNodes(bx,0);
         // Set the x-velocity
-        ParallelFor(xbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               // Set the x-velocity
               x_vel(i, j, k) = 0.0;
@@ -146,7 +146,7 @@ void Problem::init_analytic_prob(
         const Box& ybx = surroundingNodes(bx,1);
 
         // Set the y-velocity
-        ParallelFor(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               y_vel(i, j, k) = 0.0;
         });
@@ -155,7 +155,7 @@ void Problem::init_analytic_prob(
         const Box& zbx = surroundingNodes(bx,2);
 
         // Set the z-velocity
-        ParallelFor(zbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             z_vel(i, j, k) = 0.0;
         });

--- a/Exec/Upwelling/prob.H
+++ b/Exec/Upwelling/prob.H
@@ -58,7 +58,7 @@ public:
         amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
 
 private:
-    ProbParm parms;
+    [[maybe_unused]] ProbParm parms;
 };
 #endif
 

--- a/Exec/Upwelling/prob.cpp
+++ b/Exec/Upwelling/prob.cpp
@@ -23,9 +23,9 @@ Problem::Problem(const amrex::Real* /*problo*/, const amrex::Real* /*probhi*/)
  * \brief Initializes bathymetry h and surface height Zeta
  */
 void Problem::init_analytic_bathymetry (
-        int lev, const amrex::Geometry& geom,
+        int /*lev*/, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
-        REMORA const& remora,
+        REMORA const& /*remora*/,
         amrex::MultiFab& mf_h)
 {
     auto geomdata = geom.data();

--- a/Exec/Upwelling/prob.cpp
+++ b/Exec/Upwelling/prob.cpp
@@ -110,8 +110,8 @@ void Problem::init_analytic_prob(
     auto geomdata = geom.data();
     const int khi = geomdata.Domain().bigEnd()[2];
 
-    bool EWPeriodic = geomdata.isPeriodic(0);
-    bool NSPeriodic = geomdata.isPeriodic(1);
+    [[maybe_unused]] bool EWPeriodic = geomdata.isPeriodic(0);
+    [[maybe_unused]] bool NSPeriodic = geomdata.isPeriodic(1);
 
     auto T0 = m_solverChoice.T0;
     auto S0 = m_solverChoice.S0;

--- a/Source/BoundaryConditions/REMORA_FillPatch.cpp
+++ b/Source/BoundaryConditions/REMORA_FillPatch.cpp
@@ -466,7 +466,7 @@ REMORA::FillCoarsePatchMap (int lev, Real time, MultiFab* mf_to_fill, MultiFab* 
     BL_PROFILE_VAR("FillCoarsePatch()",FillCoarsePatch);
     AMREX_ASSERT(lev > 0);
 
-    MultiFab* mask;
+    MultiFab* mask = nullptr;
 
     int ncomp;
     if (fill_all) {

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -657,7 +657,7 @@ REMORA::WritePlotFile ()
  */
 void
 REMORA::WriteGenericPlotfileHeaderWithBathymetry (std::ostream &HeaderFile,
-                                                 int /*nlevels*/,
+                                                 [[maybe_unused]] int nlevels,
                                                  const Vector<BoxArray> &bArray,
                                                  const Vector<std::string> &varnames,
                                                  const Vector<Geometry>& my_geom,

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -657,7 +657,7 @@ REMORA::WritePlotFile ()
  */
 void
 REMORA::WriteGenericPlotfileHeaderWithBathymetry (std::ostream &HeaderFile,
-                                                 int nlevels,
+                                                 int /*nlevels*/,
                                                  const Vector<BoxArray> &bArray,
                                                  const Vector<std::string> &varnames,
                                                  const Vector<Geometry>& my_geom,

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -415,7 +415,7 @@ REMORA::WritePlotFile ()
     } else { // multilevel
         if (plotfile_type == PlotfileType::amrex) {
             int lev0 = 0;
-            int desired_ratio = std::max(std::max(ref_ratio[lev0][0],ref_ratio[lev0][1]),ref_ratio[lev0][2]);
+            [[maybe_unused]] int desired_ratio = std::max(std::max(ref_ratio[lev0][0],ref_ratio[lev0][1]),ref_ratio[lev0][2]);
             bool any_ratio_one = ( ( (ref_ratio[lev0][0] == 1) || (ref_ratio[lev0][1] == 1) ) ||
                                      (ref_ratio[lev0][2] == 1) );
             for (int lev = 1; lev < finest_level; lev++) {

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -795,38 +795,38 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where) {
 
         ParallelFor(makeSlab(gbx1,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int )
         {
-            if (!mskr(i,j,0)) {
+            if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0
                 Zt_avg1(i,j,0) = fill_value;
             }
         });
         ParallelFor(gbx1, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            if (!mskr(i,j,0)) {
+            if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0
                 temp(i,j,k) = fill_value;
                 salt(i,j,k) = fill_value;
             }
         });
         ParallelFor(makeSlab(ubx,2,0), 3, [=] AMREX_GPU_DEVICE (int i, int j, int , int n)
         {
-            if (!msku(i,j,0) && ubar(i,j,0)==fill_where) {
+            if (msku(i,j,0) == 0.0 && ubar(i,j,0)==fill_where) {  // Explicitly compare to 0.0
                 ubar(i,j,0,n) = fill_value;
             }
         });
         ParallelFor(makeSlab(vbx,2,0), 3, [=] AMREX_GPU_DEVICE (int i, int j, int , int n)
         {
-            if (!mskv(i,j,0) && vbar(i,j,0)==fill_where) {
+            if (mskv(i,j,0) == 0.0 && vbar(i,j,0)==fill_where) {  // Explicitly compare to 0.0
                 vbar(i,j,0,n) = fill_value;
             }
         });
         ParallelFor(ubx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            if (!msku(i,j,0) && xvel(i,j,k)==fill_where) {
+            if (msku(i,j,0) == 0.0 && xvel(i,j,k)==fill_where) {  // Explicitly compare to 0.0
                 xvel(i,j,k) = fill_value;
             }
         });
         ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            if (!mskv(i,j,0) && yvel(i,j,k)==fill_where) {
+            if (mskv(i,j,0) == 0.0 && yvel(i,j,k)==fill_where) {  // Explicitly compare to 0.0
                 yvel(i,j,k) = fill_value;
             }
         });

--- a/Source/Initialization/REMORA_init_bcs.cpp
+++ b/Source/Initialization/REMORA_init_bcs.cpp
@@ -139,7 +139,7 @@ void REMORA::init_bcs ()
         }
     };
 
-    auto f_by_side = [this, &f_set_var_bc] (std::string const& bcid, Orientation ori)
+    auto f_by_side = [&f_set_var_bc] (std::string const& bcid, Orientation ori)
     {
         ParmParse pp("remora.bc."+bcid);
         std::string bc_type_in = "null";

--- a/Source/TimeIntegration/REMORA_gls.cpp
+++ b/Source/TimeIntegration/REMORA_gls.cpp
@@ -859,6 +859,9 @@ REMORA::gls_corrector (int lev, MultiFab* mf_gls, MultiFab* mf_tke,
                 Real cff_galperin = 1.0_rt - my_Sh2*Gh;
                 Sh = my_Sh1 / cff_galperin;
                 Sm = (my_Sm3+Sh*Gh*my_Sm4)/(1.0_rt-my_Sm2*Gh);
+            } else {
+                Sh = 0.0;
+                Sm = 0.0;
             }
 
             //  Compute vertical mixing (m2/s) coefficients of momentum and

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -23,7 +23,7 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
     MultiFab& V_new = *yvel_new[lev];
     MultiFab& W_new = *zvel_new[lev];
 
-    int nvars = S_old.nComp();
+    [[maybe_unused]] int nvars = S_old.nComp();
 
     // Fill ghost cells/faces at old time
     FillPatchNoBC(lev, time, *cons_old[lev], cons_old, BdyVars::t);

--- a/Source/Utils/REMORA_DepthStretchTransform.H
+++ b/Source/Utils/REMORA_DepthStretchTransform.H
@@ -85,9 +85,9 @@ REMORA::stretch_transform (int lev)
     std::unique_ptr<MultiFab>& mf_Zt_avg1  = vec_Zt_avg1[lev];
     std::unique_ptr<MultiFab>& mf_z_phys_nd  = vec_z_phys_nd[lev];
 
-    auto s_w_dat = s_w.data();
+    [[maybe_unused]] auto s_w_dat = s_w.data();
     auto Cs_w_dat = Cs_w.data();
-    auto s_r_dat = s_r.data();
+    [[maybe_unused]] auto s_r_dat = s_r.data();
     auto Cs_r_dat = Cs_r.data();
 
     for ( MFIter mfi(*cons_new[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi )


### PR DESCRIPTION
This PR addresses several warnings and improves CI stability, especially on macOS. Key changes include:

- Initialize previously uninitialized variables `Sm` and `Sh` to 0 in `Source/TimeIntegration/REMORA_gls.cpp` when conditions are unmet.
  This may affect simulation results and should be reviewed.
- Disable shared library builds on macOS by switching to static linkage to resolve build issues.
- Fix CMake shared library builds on Linux with a minor adjustment; however, `amrex_probinit` functions may still require macOS-specific CMake handling. This was done by adjusting object library linkage (`srclib`) for better compatibility
- Address various compiler warnings:
  - Fix unused and shadowed variables
  - Use `[[maybe_unused]]` where appropriate
  - Correct comparisons involving `MultiFab` mask data
