### PR TITLE
Fix CUDA CI disk space failures

### DIFF
--- a/.github/actions/free-space-ubuntu/action.yml
+++ b/.github/actions/free-space-ubuntu/action.yml
@@ -1,0 +1,44 @@
+name: Free space on Ubuntu VMs
+description: Frees disk space on GitHub Actions Ubuntu VMs
+
+runs:
+  using: composite
+  steps:
+    - id: show-space-initial
+      run: df -h
+      shell: bash
+    - id: list-largest-packages
+      run: |
+        dpkg-query -W --showformat='${Package} ${Installed-Size}\n' | sort -k2 -n -r | awk 'NR <= 20'
+      shell: bash
+    - id: uninstall-packages
+      run: |
+        sudo apt-get update
+        sudo apt-get purge --autoremove -y azure-cli --fix-missing
+        sudo apt-get purge --autoremove -y microsoft-edge-stable --fix-missing
+        sudo apt-get purge --autoremove -y google-cloud-sdk --fix-missing
+        sudo apt-get purge --autoremove -y google-cloud-cli --fix-missing
+        sudo apt-get purge --autoremove -y '^dotnet-sdk-.*' --fix-missing
+        sudo apt-get purge --autoremove -y google-chrome-stable --fix-missing
+        sudo apt-get purge --autoremove -y '^mongodb-.*' --fix-missing
+        sudo apt-get purge --autoremove -y 'llvm-.*' --fix-missing
+        sudo apt-get purge --autoremove -y '^mysql-.*' --fix-missing
+        sudo apt-get purge --autoremove -y powershell --fix-missing
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        sudo docker image prune --all --force || true
+      shell: bash
+    - id: list-largest-packages-remaining
+      run: |
+        dpkg-query -W --showformat='${Package} ${Installed-Size}\n' | sort -k2 -n -r | awk 'NR <= 20'
+      shell: bash
+    - id: remove-directories
+      run: |
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+      shell: bash
+    - id: show-space-final
+      run: df -h
+      shell: bash

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -3,7 +3,6 @@ name: REMORA CUDA CI
 on:
   pull_request:
     branches: [development]
-  push:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -3,6 +3,7 @@ name: REMORA CUDA CI
 on:
   pull_request:
     branches: [development]
+  push:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -3,6 +3,7 @@ name: REMORA CUDA CI
 on:
   pull_request:
     branches: [development]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda-ci
@@ -26,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Free up disk space
+        uses: ./.github/actions/free-space-ubuntu
       - name: Prepare CUDA environment
         run: Submodules/AMReX/.github/workflows/dependencies/dependencies_nvcc.sh ${{matrix.cuda_ver}}
       - name: Install CCache
@@ -37,11 +40,14 @@ jobs:
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
           restore-keys: |
                ccache-${{ github.workflow }}-${{ github.job }}-git-
+      - name: Show disk space
+        run: df -h
       - name: Configure and build
         run: |
           export CCACHE_COMPRESS=1
           export CCACHE_COMPRESSLEVEL=10
-          export CCACHE_MAXSIZE=600M
+          export CCACHE_MAXSIZE=300M
+          export CCACHE_DEPEND=1
           ccache -z
 
           export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}


### PR DESCRIPTION
This PR resolves "No space left on device" errors in the CUDA CI workflow. Key changes include:

- Add reusable disk cleanup action based on ERF that frees ~24GB by removing pre-installed packages (Azure CLI, Google Cloud SDK, dotnet, etc.) and unnecessary directories
- Reduce ccache size from 600M to 300M to leave more headroom for build artifacts
- Add disk space monitoring to help diagnose future issues
- Add `workflow_dispatch` trigger for easier CI testing

This fix was tested with this action: https://github.com/jmsexton03/REMORA/actions/runs/18532155511