### PR TITLE
Spatial bulk flux

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -915,13 +915,55 @@ List of Bulk Fluxes parameters
 |                                  |                                        |                   |                |
 |                                  |                                        | Values            |                |
 +==================================+========================================+===================+================+
-| **remora.air_temperature**       | Air temperature [C]                    | Real number       | 23.567         |
+| **remora.air_temperature**       | Air temperature [C] (used as           | Real number       | 23.567         |
+|                                  |                                        |                   |                |
+|                                  | uniform value if                       |                   |                |
+|                                  |                                        |                   |                |
+|                                  | **Tair_from_netcdf** is false)         |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.air_humidity**          | Relative humidity of air               | Real number       | 0.776          |
 |                                  |                                        |                   |                |
-|                                  |                                        | from 0 to 1       |                |
+|                                  | (used as uniform value if              | from 0 to 1       |                |
+|                                  |                                        |                   |                |
+|                                  | **qair_from_netcdf** is false)         |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
-| **remora.air_pressure**          | Air pressure [hPa]                     | Real number       | 1013.48        |
+| **remora.air_pressure**          | Air pressure [hPa] (used as            | Real number       | 1013.48        |
+|                                  |                                        |                   |                |
+|                                  | uniform value if                       |                   |                |
+|                                  |                                        |                   |                |
+|                                  | **Pair_from_netcdf** is false)         |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.surface_radiation_flux**| Shortwave radiation flux [W/m^2]       | Real number       | 0.0            |
+|                                  |                                        |                   |                |
+|                                  | (used as uniform value if              |                   |                |
+|                                  |                                        |                   |                |
+|                                  | **srflx_from_netcdf** is false)        |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.Tair_from_netcdf**      | Load air temperature from NetCDF       | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | file (spatially varying)               |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.qair_from_netcdf**      | Load air humidity from NetCDF          | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | file (spatially varying)               |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.qair_is_percent**       | Convert qair from percentage           | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | (0-100) to fraction (0-1).             |                   |                |
+|                                  |                                        |                   |                |
+|                                  | Only used if                           |                   |                |
+|                                  |                                        |                   |                |
+|                                  | **qair_from_netcdf** is true           |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.Pair_from_netcdf**      | Load air pressure from NetCDF          | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | file (spatially varying)               |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.srflx_from_netcdf**     | Load shortwave radiation flux          | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | from NetCDF file                       |                   |                |
+|                                  |                                        |                   |                |
+|                                  | (spatially varying)                    |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.blk_ZQ**                | Height [m] of atmospheric              | Real number       | 10.0           |
 |                                  |                                        |                   |                |
@@ -957,6 +999,21 @@ List of Bulk Fluxes parameters
 |                                  |                                        |                   |                |
 |                                  | and precipitation                      |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
+
+.. note::
+
+   When loading atmospheric forcing variables from NetCDF files (by setting
+   **Tair_from_netcdf**, **qair_from_netcdf**, **Pair_from_netcdf**, or
+   **srflx_from_netcdf** to true), these variables are read from the file
+   specified by **remora.nc_frc_file** (see :ref:`list-of-parameters surface-forcing`).
+   The NetCDF file must contain variables named ``Tair``, ``qair``, ``Pair``,
+   and ``swrad`` respectively, with the same spatial dimensions as the model grid.
+   Time interpolation is performed automatically based on the simulation time.
+
+   The **qair_is_percent** flag should be set to true if the relative humidity
+   in the NetCDF file is stored as a percentage (0-100) rather than as a
+   fraction (0-1). This conversion is applied after loading and includes proper
+   ghost cell synchronization.
 
 Numerical Algorithms
 ====================

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -422,6 +422,10 @@ void REMORA::resize_stuff(int lev)
     vec_bvstr.resize(lev+1);
     vec_uwind.resize(lev+1);
     vec_vwind.resize(lev+1);
+    vec_Tair.resize(lev+1);
+    vec_qair.resize(lev+1);
+    vec_Pair.resize(lev+1);
+    vec_srflx.resize(lev+1);
     vec_alpha.resize(lev+1);
     vec_beta.resize(lev+1);
 
@@ -630,6 +634,10 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
     if (solverChoice.bulk_fluxes) {
         vec_uwind[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, surface wind u
         vec_vwind[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, surface wind v
+        vec_Tair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, air temperature
+        vec_qair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, specific humidity
+        vec_Pair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, air pressure
+        vec_srflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, shortwave radiation flux
         vec_alpha[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_beta[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_lrflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
@@ -637,6 +645,10 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
         vec_shflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_rain[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_evap[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
+        vec_Tair[lev]->setVal(solverChoice.Tair);
+        vec_qair[lev]->setVal(solverChoice.Hair); // Hair can be specific humidity or RH
+        vec_Pair[lev]->setVal(solverChoice.Pair);
+        vec_srflx[lev]->setVal(solverChoice.srflux);
         vec_lhflx[lev]->setVal(0.0_rt);
         vec_shflx[lev]->setVal(0.0_rt);
         vec_rain[lev]->setVal(solverChoice.rain);

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -316,6 +316,14 @@ public:
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_uwind;
     /** \brief Wind in the v direction, defined at rho-points */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_vwind;
+    /** \brief Air temperature [°C], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_Tair;
+    /** \brief Specific humidity [kg/kg], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_qair;
+    /** \brief Air pressure [mb], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_Pair;
+    /** \brief Shortwave radiation flux [W/m²], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_srflx;
 
     /** \brief longwave radiation */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_lrflx;
@@ -522,6 +530,10 @@ public:
                       amrex::MultiFab* mf_cons,
                       amrex::MultiFab* mf_uwind,
                       amrex::MultiFab* mf_vwind,
+                      amrex::MultiFab* mf_Tair,
+                      amrex::MultiFab* mf_qair,
+                      amrex::MultiFab* mf_Pair,
+                      amrex::MultiFab* mf_srflx,
                       amrex::MultiFab* mf_evap,
                       amrex::MultiFab* mf_sustr,
                       amrex::MultiFab* mf_svstr,
@@ -1083,6 +1095,14 @@ private:
     NCTimeSeries* Uwind_data_from_file;
     /** \brief Data container for v-direction wind read from file */
     NCTimeSeries* Vwind_data_from_file;
+    /** \brief Data container for air temperature read from file */
+    NCTimeSeries* Tair_data_from_file;
+    /** \brief Data container for specific humidity read from file */
+    NCTimeSeries* qair_data_from_file;
+    /** \brief Data container for air pressure read from file */
+    NCTimeSeries* Pair_data_from_file;
+    /** \brief Data container for shortwave radiation flux read from file */
+    NCTimeSeries* srflx_data_from_file;
 
     /** \brief Data container for ubar climatology data read from file */
     NCTimeSeries* ubar_clim_data_from_file;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -725,6 +725,44 @@ REMORA::set_wind(int lev)
         Vwind_data_from_file->update_interpolated_to_time(t_old[lev]);
         FillPatch(lev, t_old[lev], *vec_uwind[lev], GetVecOfPtrs(vec_uwind),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         FillPatch(lev, t_old[lev], *vec_vwind[lev], GetVecOfPtrs(vec_vwind),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        
+        // Conditionally update atmospheric fields if loaded from NetCDF
+        if (solverChoice.Tair_from_netcdf) {
+            Tair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_Tair[lev], GetVecOfPtrs(vec_Tair),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
+        if (solverChoice.qair_from_netcdf) {
+            qair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_qair[lev], GetVecOfPtrs(vec_qair),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+            
+            // Convert qair from percentage (0-100) to specific humidity (0-1) if needed
+            if (solverChoice.qair_is_percent) {
+                vec_qair[lev]->mult(0.01);
+                
+                // Update ghost cells after modification
+                vec_qair[lev]->FillBoundary(geom[lev].periodicity());
+            }
+        }
+        if (solverChoice.Pair_from_netcdf) {
+            Pair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_Pair[lev], GetVecOfPtrs(vec_Pair),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
+        if (solverChoice.srflx_from_netcdf) {
+            srflx_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_srflx[lev], GetVecOfPtrs(vec_srflx),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+            // Sanity check for unreasonable values - only at step 10
+            if (istep[lev] == 10) {
+                Real srflx_min = vec_srflx[lev]->min(0);
+                Real srflx_max = vec_srflx[lev]->max(0);
+                if (ParallelDescriptor::IOProcessor()) {
+                    amrex::Print() << "SANITY CHECK (istep=10): srflx min=" << srflx_min 
+                                  << ", max=" << srflx_max << " W/m²\n";
+                    if (std::abs(srflx_min) > 2000.0 || std::abs(srflx_max) > 2000.0) {
+                        amrex::Print() << "  WARNING: srflx values out of reasonable range\n";
+                    }
+                }
+            }
+        }
 #endif
     }
 }
@@ -834,6 +872,24 @@ REMORA::init_only (int lev, Real time)
         Vwind_data_from_file = new NCTimeSeries(nc_frc_file, "Vwind", frc_time_varname, geom[lev].Domain(),vec_vwind[lev].get(), true, false);
         Uwind_data_from_file->Initialize();
         Vwind_data_from_file->Initialize();
+        
+        // Conditionally load atmospheric forcing fields from NetCDF based on user flags
+        if (solverChoice.Tair_from_netcdf) {
+            Tair_data_from_file = new NCTimeSeries(nc_frc_file, "Tair", frc_time_varname, geom[lev].Domain(),vec_Tair[lev].get(), true, false);
+            Tair_data_from_file->Initialize();
+        }
+        if (solverChoice.qair_from_netcdf) {
+            qair_data_from_file = new NCTimeSeries(nc_frc_file, "qair", frc_time_varname, geom[lev].Domain(),vec_qair[lev].get(), true, false);
+            qair_data_from_file->Initialize();
+        }
+        if (solverChoice.Pair_from_netcdf) {
+            Pair_data_from_file = new NCTimeSeries(nc_frc_file, "Pair", frc_time_varname, geom[lev].Domain(),vec_Pair[lev].get(), true, false);
+            Pair_data_from_file->Initialize();
+        }
+        if (solverChoice.srflx_from_netcdf) {
+            srflx_data_from_file = new NCTimeSeries(nc_frc_file, "swrad", frc_time_varname, geom[lev].Domain(),vec_srflx[lev].get(), true, false);
+            srflx_data_from_file->Initialize();
+        }
     } else if (solverChoice.smflux_type == SMFluxType::netcdf) {
         if (nc_frc_file.empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for surface momentum fluxes");

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -750,18 +750,6 @@ REMORA::set_wind(int lev)
         if (solverChoice.srflx_from_netcdf) {
             srflx_data_from_file->update_interpolated_to_time(t_old[lev]);
             FillPatch(lev, t_old[lev], *vec_srflx[lev], GetVecOfPtrs(vec_srflx),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
-            // Sanity check for unreasonable values - only at step 10
-            if (istep[lev] == 10) {
-                Real srflx_min = vec_srflx[lev]->min(0);
-                Real srflx_max = vec_srflx[lev]->max(0);
-                if (ParallelDescriptor::IOProcessor()) {
-                    amrex::Print() << "SANITY CHECK (istep=10): srflx min=" << srflx_min 
-                                  << ", max=" << srflx_max << " W/m²\n";
-                    if (std::abs(srflx_min) > 2000.0 || std::abs(srflx_max) > 2000.0) {
-                        amrex::Print() << "  WARNING: srflx values out of reasonable range\n";
-                    }
-                }
-            }
         }
 #endif
     }

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -201,9 +201,6 @@ struct SolverChoice {
         pp.queryAdd("Tair_from_netcdf",Tair_from_netcdf);
         pp.queryAdd("qair_from_netcdf",qair_from_netcdf);
         pp.queryAdd("qair_is_percent",qair_is_percent);
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "STARTUP: qair_is_percent = " << (qair_is_percent ? "true" : "false") << "\n";
-        }
         pp.queryAdd("Pair_from_netcdf",Pair_from_netcdf);
 
         if (eminusp_correct_ssh and !eminusp) {

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -188,6 +188,7 @@ struct SolverChoice {
         pp.queryAdd("air_temperature",Tair);
         pp.queryAdd("air_humidity",Hair);
         pp.queryAdd("surface_radiation_flux",srflux);
+        pp.queryAdd("srflx_from_netcdf",srflx_from_netcdf);
         pp.queryAdd("cloud",cloud);
         pp.queryAdd("rain",rain);
         pp.queryAdd("blk_ZQ",blk_ZQ);
@@ -195,6 +196,15 @@ struct SolverChoice {
         pp.queryAdd("blk_ZW",blk_ZW);
         pp.queryAdd("eminusp",eminusp);
         pp.queryAdd("eminusp_correct_ssh",eminusp_correct_ssh);
+
+        // Control flags for loading atmospheric variables from NetCDF
+        pp.queryAdd("Tair_from_netcdf",Tair_from_netcdf);
+        pp.queryAdd("qair_from_netcdf",qair_from_netcdf);
+        pp.queryAdd("qair_is_percent",qair_is_percent);
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "STARTUP: qair_is_percent = " << (qair_is_percent ? "true" : "false") << "\n";
+        }
+        pp.queryAdd("Pair_from_netcdf",Pair_from_netcdf);
 
         if (eminusp_correct_ssh and !eminusp) {
             amrex::Abort("If evaporation minus precipitation (E-P) sea surface height correct in is on, E-P must be on as well (remora.eminusp=true)");
@@ -552,6 +562,13 @@ struct SolverChoice {
     bool        bulk_fluxes           = false;
     bool        do_temp_flux        = false;
     bool        do_salt_flux        = false;
+
+    // Control flags for loading atmospheric variables from NetCDF
+    bool        Tair_from_netcdf      = false;
+    bool        qair_from_netcdf      = false;
+    bool        Pair_from_netcdf      = false;
+    bool        srflx_from_netcdf     = false;
+    bool        qair_is_percent       = false;
 
     bool        do_rivers             = false;
     bool        do_rivers_temp        = true;

--- a/Source/TimeIntegration/REMORA_advance_2d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_2d.cpp
@@ -420,14 +420,6 @@ REMORA::advance_2d (int lev,
                 rhs_zeta(i,j,0) = (DUon(i,j,0)-DUon(i+1,j,0))+
                                   (DVom(i,j,0)-DVom(i,j+1,0));
                 zeta_new(i,j,0) = (zeta(i,j,0,kstp)+ pm(i,j,0)*pn(i,j,0)*cff1*rhs_zeta(i,j,0)) * mskr(i,j,0);
-                if (i == 300 && j == 125) {
-                    amrex::Print() << "rhs_zeta(" << i << "," << j << ")=" << rhs_zeta(i,j,0)
-                                   << " DUon=" << DUon(i,j,0)
-                                   << " DVom=" << DVom(i,j,0)
-                                   << " cff1=" << cff1
-                                   << " zeta_new=" << zeta_new(i,j,0) << "\n"
-                                   << "h(i,j)=" << h(i,j,0) << "\n";
-                }
                 Dnew(i,j,0) = zeta_new(i,j,0)+h(i,j,0);
 
                 //Pressure gradient terms:
@@ -449,15 +441,7 @@ REMORA::advance_2d (int lev,
                                 (DVom(i,j,0)-DVom(i,j+1,0));
                 zeta_new(i,j,0)=(zeta(i,j,0,kstp)+
                                 pm(i,j,0)*pn(i,j,0)*cff1*rhs_zeta(i,j,0)) * mskr(i,j,0);
-                Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);
-                if (i == 300 && j == 125) {
-                    amrex::Print() << "rhs_zeta(" << i << "," << j << ")=" << rhs_zeta(i,j,0)
-                                    << " DUon=" << DUon(i,j,0)
-                                    << " DVom=" << DVom(i,j,0)
-                                    << " cff1=" << cff1
-                                    << " zeta_new=" << zeta_new(i,j,0) << "\n"
-                                    << "h(i,j)=" << h(i,j,0) << "\n";    
-                }             
+                Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);          
                 //Pressure gradient terms
                 zwrk(i,j,0)=cff5*zeta(i,j,0,krhs)+
                     cff4*(zeta(i,j,0,kstp)+zeta_new(i,j,0));
@@ -483,15 +467,7 @@ REMORA::advance_2d (int lev,
                                          cff2*rzeta(i,j,0,kstp)-
                                          cff3*rzeta(i,j,0,ptsk));
                 zeta_new(i,j,0) *= mskr(i,j,0);
-                Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);
-                if (i == 300 && j == 125) {
-                    amrex::Print() << "grid point(" << i << "," << j << ")"
-                                    << " DUon=" << DUon(i,j,0)
-                                    << " DVom=" << DVom(i,j,0)
-                                    << " cff1=" << cff1
-                                    << " zeta_new=" << zeta_new(i,j,0) << "\n"
-                                    << "h(i,j)=" << h(i,j,0) << "\n"; 
-                }                               
+                Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);                          
                 //Pressure gradient terms
                 zwrk(i,j,0)=cff5*zeta_new(i,j,0)+cff4*zeta(i,j,0,krhs);
                 gzeta(i,j,0)=(fac+rhoS(i,j,0))*zwrk(i,j,0);

--- a/Source/TimeIntegration/REMORA_advance_2d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_2d.cpp
@@ -420,6 +420,14 @@ REMORA::advance_2d (int lev,
                 rhs_zeta(i,j,0) = (DUon(i,j,0)-DUon(i+1,j,0))+
                                   (DVom(i,j,0)-DVom(i,j+1,0));
                 zeta_new(i,j,0) = (zeta(i,j,0,kstp)+ pm(i,j,0)*pn(i,j,0)*cff1*rhs_zeta(i,j,0)) * mskr(i,j,0);
+                if (i == 300 && j == 125) {
+                    amrex::Print() << "rhs_zeta(" << i << "," << j << ")=" << rhs_zeta(i,j,0)
+                                   << " DUon=" << DUon(i,j,0)
+                                   << " DVom=" << DVom(i,j,0)
+                                   << " cff1=" << cff1
+                                   << " zeta_new=" << zeta_new(i,j,0) << "\n"
+                                   << "h(i,j)=" << h(i,j,0) << "\n";
+                }
                 Dnew(i,j,0) = zeta_new(i,j,0)+h(i,j,0);
 
                 //Pressure gradient terms:
@@ -433,7 +441,7 @@ REMORA::advance_2d (int lev,
 
             Real cff1=2.0_rt * dtfast_lev;
             Real cff4=4.0_rt / 25.0_rt;
-            Real cff5=1.0_rt - 2.0_rt*cff4;
+            Real cff5=1.0_rt - 2.0_rt*cff4;          
 
             ParallelFor(makeSlab(tbxp1,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int )
             {
@@ -442,6 +450,14 @@ REMORA::advance_2d (int lev,
                 zeta_new(i,j,0)=(zeta(i,j,0,kstp)+
                                 pm(i,j,0)*pn(i,j,0)*cff1*rhs_zeta(i,j,0)) * mskr(i,j,0);
                 Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);
+                if (i == 300 && j == 125) {
+                    amrex::Print() << "rhs_zeta(" << i << "," << j << ")=" << rhs_zeta(i,j,0)
+                                    << " DUon=" << DUon(i,j,0)
+                                    << " DVom=" << DVom(i,j,0)
+                                    << " cff1=" << cff1
+                                    << " zeta_new=" << zeta_new(i,j,0) << "\n"
+                                    << "h(i,j)=" << h(i,j,0) << "\n";    
+                }             
                 //Pressure gradient terms
                 zwrk(i,j,0)=cff5*zeta(i,j,0,krhs)+
                     cff4*(zeta(i,j,0,kstp)+zeta_new(i,j,0));
@@ -468,6 +484,14 @@ REMORA::advance_2d (int lev,
                                          cff3*rzeta(i,j,0,ptsk));
                 zeta_new(i,j,0) *= mskr(i,j,0);
                 Dnew(i,j,0)=zeta_new(i,j,0)+h(i,j,0);
+                if (i == 300 && j == 125) {
+                    amrex::Print() << "grid point(" << i << "," << j << ")"
+                                    << " DUon=" << DUon(i,j,0)
+                                    << " DVom=" << DVom(i,j,0)
+                                    << " cff1=" << cff1
+                                    << " zeta_new=" << zeta_new(i,j,0) << "\n"
+                                    << "h(i,j)=" << h(i,j,0) << "\n"; 
+                }                               
                 //Pressure gradient terms
                 zwrk(i,j,0)=cff5*zeta_new(i,j,0)+cff4*zeta(i,j,0,krhs);
                 gzeta(i,j,0)=(fac+rhoS(i,j,0))*zwrk(i,j,0);

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -7,6 +7,10 @@ using namespace amrex;
  * @param[in   ] mf_cons        scalar data: temperature, salinity, passsive scalar, etc
  * @param[in   ] mf_uwind       u-direction wind dvelocity
  * @param[in   ] mf_vwind       v-direction wind dvelocity
+ * @param[in   ] mf_Tair        air temperature [°C]
+ * @param[in   ] mf_qair        specific humidity [kg/kg]
+ * @param[in   ] mf_Pair        air pressure [mb]
+ * @param[in   ] mf_srflx       shortwave radiation flux [W/m²]
  * @param[inout] mf_evap        evaporation rate
  * @param[  out] mf_sustr       u-direction surface momentum stress
  * @param[  out] mf_svstr       v-direction surface momentum stress
@@ -18,6 +22,8 @@ using namespace amrex;
  */
 void
 REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* mf_vwind,
+                     MultiFab* mf_Tair, MultiFab* mf_qair, MultiFab* mf_Pair,
+                     MultiFab* mf_srflx,
                      MultiFab* mf_evap, MultiFab* mf_sustr, MultiFab* mf_svstr,
                      MultiFab* mf_stflux, MultiFab* mf_lrflx, MultiFab* mf_lhflx,
                      MultiFab* mf_shflx,
@@ -29,10 +35,15 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
     const DistributionMapping& dm = mf_cons->DistributionMap();
     MultiFab mf_Taux(ba, dm, 1, IntVect(NGROW,NGROW,0));
     MultiFab mf_Tauy(ba, dm, 1, IntVect(NGROW,NGROW,0));
+    
     // temps: Taux, Tauy,
     for ( MFIter mfi(*mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         Array4<Real const> const& uwind = mf_uwind->const_array(mfi);
         Array4<Real const> const& vwind = mf_vwind->const_array(mfi);
+        Array4<Real const> const& Tair_arr = mf_Tair->const_array(mfi);
+        Array4<Real const> const& qair_arr = mf_qair->const_array(mfi);
+        Array4<Real const> const& Pair_arr = mf_Pair->const_array(mfi);
+        Array4<Real const> const& srflx_arr = mf_srflx->const_array(mfi);
         Array4<Real const> const& cons = mf_cons->const_array(mfi);
         Array4<Real> const& sustr = mf_sustr->array(mfi);
         Array4<Real> const& svstr = mf_svstr->array(mfi);
@@ -51,11 +62,6 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
 
         Real Hscale = solverChoice.rho0 * Cp;
         Real Hscale2 = 1.0_rt / (solverChoice.rho0 * Cp);
-        Real srflux = solverChoice.srflux;
-        Real PairM = solverChoice.Pair;
-        Real TairC = solverChoice.Tair;
-        Real TairK = solverChoice.Tair + 273.16_rt;
-        Real Hair = solverChoice.Hair;
         Real cloud = solverChoice.cloud;
         Real blk_ZQ = solverChoice.blk_ZQ;
         Real blk_ZT = solverChoice.blk_ZT;
@@ -69,6 +75,12 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Box gbx1 = bx; gbx1.grow(IntVect(NGROW,NGROW,0));
 
         ParallelFor(makeSlab(gbx1,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int ) {
+            // Get spatially-varying atmospheric forcing from input arrays
+            Real PairM = Pair_arr(i,j,0);  // Air pressure [mb]
+            Real TairC = Tair_arr(i,j,0);  // Air temperature [°C]
+            Real TairK = TairC + 273.16_rt; // Air temperature [K]
+            Real Hair = qair_arr(i,j,0);   // Specific humidity [kg/kg] or RH [fraction]
+
             // Input bulk parametrization fields
             Real wind_mag = std::sqrt(uwind(i,j,0)*uwind(i,j,0) + vwind(i,j,0) * vwind(i,j,0)) + eps;
             Real TseaK = cons(i,j,N,Temp_comp) + 273.16_rt;
@@ -182,7 +194,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
 
             Real VisAir=1.326E-5_rt*(1.0_rt+TairC*(6.542E-3_rt+TairC*
                                      (8.301E-6_rt-4.84E-9_rt*TairC)));
-
+\
             //  Compute latent heat of vaporization (J/kg) at sea surface, Hlv.
 
             Real Hlv = (2.501_rt-0.00237_rt*cons(i,j,N,Temp_comp))*1.0e6_rt;
@@ -278,7 +290,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             // Compute transfer coefficients for momentum (Cd).
             Real Wspeed=std::sqrt(wind_mag*wind_mag+Wgus*Wgus);
             Cd=Wstar*Wstar/(Wspeed*Wspeed+eps);
-
+            
             // Compute turbulent sensible heat flux (W/m2), Hs.
             Real Hs=-blk_Cpa*rhoAir*Wstar*Tstar;
 
@@ -297,23 +309,25 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             // Compute turbulent latent heat flux (W/m2), Hl.
 
             Real Hl=-Hlv*rhoAir*Wstar*Qstar;
-
+            
             // Compute Webb correction (Webb effect) to latent heat flux, Hlw.
             Real upvel=-1.61_rt*Wstar*Qstar-
                         (1.0_rt+1.61_rt*Q)*Wstar*Tstar/TairK;
             Real Hlw=rhoAir*Hlv*upvel*Q;
             LHeat=(Hl+Hlw) * mskr(i,j,0);
-
+            
             // Compute momentum flux (N/m2) due to rainfall (kg/m2/s).
             Taur=0.85_rt*rain(i,j,0)*wind_mag;
 
             // Compute wind stress components (N/m2), Tau.
             cff=rhoAir*Cd*Wspeed;
+            // amrex::Print() << "rhoAir: " << rhoAir << " Cd: " << Cd << " Wspeed: " << Wspeed << " cff: " << cff << "\n";
             Real sign_u = (uwind(i,j,0) >= 0.0_rt) ? 1 : -1;
             Real sign_v = (vwind(i,j,0) >= 0.0_rt) ? 1 : -1;
             Taux(i,j,0)=(cff*uwind(i,j,0)+Taur*sign_u) * mskr(i,j,0);
             Tauy(i,j,0)=(cff*vwind(i,j,0)+Taur*sign_v) * mskr(i,j,0);
-
+            // amrex::Print() << "Taux: " << Taux(i,j,0) << " Tauy: " << Tauy(i,j,0) << "\n";
+            
             //=======================================================================
             //  Compute surface net heat flux and surface wind stress.
             //=======================================================================
@@ -346,7 +360,8 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             lrflx(i,j,0) = LRad*Hscale2;
             lhflx(i,j,0) = -LHeat*Hscale2;
             shflx(i,j,0) = -SHeat*Hscale2;
-            stflux(i,j,0,Temp_comp)=(srflux + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0)) * mskr(i,j,0);
+            // Note: srflx from NetCDF is in W/m², convert to degC m/s by multiplying by Hscale2
+            stflux(i,j,0,Temp_comp)=(srflx_arr(i,j,0)*Hscale2 + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0)) * mskr(i,j,0);
             evap(i,j,0) = (LHeat / Hlv+eps) * mskr(i,j,0);
             stflux(i,j,0,Salt_comp) = mskr(i,j,0) * (evap(i,j,0)-rain(i,j,0)) / rhow;
         });

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -182,6 +182,8 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
     if (solverChoice.bulk_fluxes) {
         bulk_fluxes(lev, cons_old[lev],vec_uwind[lev].get(),vec_vwind[lev].get(),
+                    vec_Tair[lev].get(),vec_qair[lev].get(),vec_Pair[lev].get(),
+                    vec_srflx[lev].get(),
                     vec_evap[lev].get(),
                     vec_sustr[lev].get(),vec_svstr[lev].get(),vec_stflux[lev].get(),
                     vec_lrflx[lev].get(),vec_lhflx[lev].get(),vec_shflx[lev].get(),N);


### PR DESCRIPTION
Updates to the source code to allow for spatially varying bulk flux variables, previously 2d winds were loaded from netcdf but not air temperature, humidity, etc. True/false flags are set by variable in the inputs file to specify constant or netcdf and if true variables are loaded in following same method as netcdf winds from the same forcing file. ROMS forcing file gives humidity in percentage 0-100 rather than fraction 0-1, so a step is added to convert from percentage to fraction if specified in input file. Documentation has been updated to reflect the new options. Code has been tested, but double checking that I haven't overlooked something or checking if there is a better way to implement any of this would be great. 