### PR TITLE
Added spatially varying salt flux variables, i.e. eminusp, rain, etc

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -985,9 +985,31 @@ List of Bulk Fluxes parameters
 +----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.cloud**                 | Cloud cover fraction (0=clear sky,     | Real number       | 0.0            |
 |                                  |                                        |                   |                |
-|                                  | 1=overcast)                            | from 0 to 1       |                |
+|                                  | 1=overcast) (used as uniform           | from 0 to 1       |                |
+|                                  |                                        |                   |                |
+|                                  | value if **cloud_from_netcdf**         |                   |                |
+|                                  |                                        |                   |                |
+|                                  | is false)                              |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.rain**                  | Precipitation rate [kg/m^2/s]          | Real number       | 0.0            |
+|                                  |                                        |                   |                |
+|                                  | (used as uniform value if              |                   |                |
+|                                  |                                        |                   |                |
+|                                  | **rain_from_netcdf** is false)         |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.cloud_from_netcdf**     | Load cloud cover from NetCDF           | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | file (spatially varying)               |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.rain_from_netcdf**      | Load precipitation rate from           | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | NetCDF file (spatially varying)        |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.EminusP_from_netcdf**   | Load evaporation minus                 | true / false      | false          |
+|                                  |                                        |                   |                |
+|                                  | precipitation from NetCDF file         |                   |                |
+|                                  |                                        |                   |                |
+|                                  | (spatially varying)                    |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.eminusp**               | Whether to do E-P prescription for     | true / false      | false          |
 |                                  |                                        |                   |                |
@@ -1003,11 +1025,13 @@ List of Bulk Fluxes parameters
 .. note::
 
    When loading atmospheric forcing variables from NetCDF files (by setting
-   **Tair_from_netcdf**, **qair_from_netcdf**, **Pair_from_netcdf**, or
-   **srflx_from_netcdf** to true), these variables are read from the file
+   **Tair_from_netcdf**, **qair_from_netcdf**, **Pair_from_netcdf**,
+   **srflx_from_netcdf**, **rain_from_netcdf**, **cloud_from_netcdf**, or
+   **EminusP_from_netcdf** to true), these variables are read from the file
    specified by **remora.nc_frc_file** (see :ref:`list-of-parameters surface-forcing`).
    The NetCDF file must contain variables named ``Tair``, ``qair``, ``Pair``,
-   and ``swrad`` respectively, with the same spatial dimensions as the model grid.
+   ``swrad``, ``rain``, ``cloud``, and ``EminusP`` respectively, with the same
+   spatial dimensions as the model grid.
    Time interpolation is performed automatically based on the simulation time.
 
    The **qair_is_percent** flag should be set to true if the relative humidity

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -426,6 +426,8 @@ void REMORA::resize_stuff(int lev)
     vec_qair.resize(lev+1);
     vec_Pair.resize(lev+1);
     vec_srflx.resize(lev+1);
+    vec_cloud.resize(lev+1);
+    vec_EminusP.resize(lev+1);
     vec_alpha.resize(lev+1);
     vec_beta.resize(lev+1);
 
@@ -638,6 +640,8 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
         vec_qair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, specific humidity
         vec_Pair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, air pressure
         vec_srflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, shortwave radiation flux
+        vec_cloud[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, cloud cover fraction
+        vec_EminusP[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, evaporation minus precipitation
         vec_alpha[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_beta[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
         vec_lrflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));
@@ -649,6 +653,8 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
         vec_qair[lev]->setVal(solverChoice.Hair); // Hair can be specific humidity or RH
         vec_Pair[lev]->setVal(solverChoice.Pair);
         vec_srflx[lev]->setVal(solverChoice.srflux);
+        vec_cloud[lev]->setVal(solverChoice.cloud);
+        vec_EminusP[lev]->setVal(0.0_rt);
         vec_lhflx[lev]->setVal(0.0_rt);
         vec_shflx[lev]->setVal(0.0_rt);
         vec_rain[lev]->setVal(solverChoice.rain);

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -345,6 +345,10 @@ public:
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_rain;
     /** \brief evaporation rate [kg/m^2/s] */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_evap;
+    /** \brief cloud cover fraction [0-1], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_cloud;
+    /** \brief evaporation minus precipitation [kg/m^2/s], defined at rho-points */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_EminusP;
 
     /** \brief Linear drag coefficient [m/s], defined at rho points */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_rdrag;
@@ -1103,6 +1107,12 @@ private:
     NCTimeSeries* Pair_data_from_file;
     /** \brief Data container for shortwave radiation flux read from file */
     NCTimeSeries* srflx_data_from_file;
+    /** \brief Data container for precipitation rate read from file */
+    NCTimeSeries* rain_data_from_file;
+    /** \brief Data container for cloud cover fraction read from file */
+    NCTimeSeries* cloud_data_from_file;
+    /** \brief Data container for evaporation minus precipitation read from file */
+    NCTimeSeries* EminusP_data_from_file;
 
     /** \brief Data container for ubar climatology data read from file */
     NCTimeSeries* ubar_clim_data_from_file;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -757,6 +757,21 @@ REMORA::set_wind(int lev)
             FillPatch(lev, t_old[lev], *vec_srflx[lev], GetVecOfPtrs(vec_srflx),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
+        if (solverChoice.rain_from_netcdf) {
+            rain_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_rain[lev], GetVecOfPtrs(vec_rain),
+                      BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
+        if (solverChoice.cloud_from_netcdf) {
+            cloud_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_cloud[lev], GetVecOfPtrs(vec_cloud),
+                      BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
+        if (solverChoice.EminusP_from_netcdf) {
+            EminusP_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_EminusP[lev], GetVecOfPtrs(vec_EminusP),
+                      BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
 #endif
     }
 }
@@ -883,6 +898,18 @@ REMORA::init_only (int lev, Real time)
         if (solverChoice.srflx_from_netcdf) {
             srflx_data_from_file = new NCTimeSeries(nc_frc_file, "swrad", frc_time_varname, geom[lev].Domain(),vec_srflx[lev].get(), true, false);
             srflx_data_from_file->Initialize();
+        }
+        if (solverChoice.rain_from_netcdf) {
+            rain_data_from_file = new NCTimeSeries(nc_frc_file, "rain", frc_time_varname, geom[lev].Domain(),vec_rain[lev].get(), true, false);
+            rain_data_from_file->Initialize();
+        }
+        if (solverChoice.cloud_from_netcdf) {
+            cloud_data_from_file = new NCTimeSeries(nc_frc_file, "cloud", frc_time_varname, geom[lev].Domain(),vec_cloud[lev].get(), true, false);
+            cloud_data_from_file->Initialize();
+        }
+        if (solverChoice.EminusP_from_netcdf) {
+            EminusP_data_from_file = new NCTimeSeries(nc_frc_file, "EminusP", frc_time_varname, geom[lev].Domain(),vec_EminusP[lev].get(), true, false);
+            EminusP_data_from_file->Initialize();
         }
     } else if (solverChoice.smflux_type == SMFluxType::netcdf) {
         if (nc_frc_file.empty()) {

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -202,6 +202,9 @@ struct SolverChoice {
         pp.queryAdd("qair_from_netcdf",qair_from_netcdf);
         pp.queryAdd("qair_is_percent",qair_is_percent);
         pp.queryAdd("Pair_from_netcdf",Pair_from_netcdf);
+        pp.queryAdd("rain_from_netcdf",rain_from_netcdf);
+        pp.queryAdd("cloud_from_netcdf",cloud_from_netcdf);
+        pp.queryAdd("EminusP_from_netcdf",EminusP_from_netcdf);
 
         if (eminusp_correct_ssh and !eminusp) {
             amrex::Abort("If evaporation minus precipitation (E-P) sea surface height correct in is on, E-P must be on as well (remora.eminusp=true)");
@@ -565,6 +568,9 @@ struct SolverChoice {
     bool        qair_from_netcdf      = false;
     bool        Pair_from_netcdf      = false;
     bool        srflx_from_netcdf     = false;
+    bool        rain_from_netcdf      = false;
+    bool        cloud_from_netcdf     = false;
+    bool        EminusP_from_netcdf   = false;
     bool        qair_is_percent       = false;
 
     bool        do_rivers             = false;

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -363,7 +363,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             lhflx(i,j,0) = -LHeat*Hscale2;
             shflx(i,j,0) = -SHeat*Hscale2;
             // Note: srflx from NetCDF is in W/m², convert to degC m/s by multiplying by Hscale2
-            stflux(i,j,0,Temp_comp)=(srflx_arr(i,j,0)*Hscale2 + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0)) * mskr(i,j,0);
+            stflux(i,j,0,Temp_comp)=(srflux*Hscale2 + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0)) * mskr(i,j,0);
             evap(i,j,0) = (LHeat / Hlv+eps) * mskr(i,j,0);
             stflux(i,j,0,Salt_comp) = mskr(i,j,0) * (evap(i,j,0)-rain(i,j,0)) / rhow;
         });

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -59,10 +59,10 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Array4<const Real> const& msku  = vec_msku[lev]->const_array(mfi);
         Array4<const Real> const& mskv  = vec_mskv[lev]->const_array(mfi);
         Array4<const Real> const& rain  = vec_rain[lev]->const_array(mfi);
+        Array4<const Real> const& cloud_arr = vec_cloud[lev]->const_array(mfi);
 
         Real Hscale = solverChoice.rho0 * Cp;
         Real Hscale2 = 1.0_rt / (solverChoice.rho0 * Cp);
-        Real cloud = solverChoice.cloud;
         Real blk_ZQ = solverChoice.blk_ZQ;
         Real blk_ZT = solverChoice.blk_ZT;
         Real blk_ZW = solverChoice.blk_ZW;
@@ -80,6 +80,8 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             Real TairC = Tair_arr(i,j,0);  // Air temperature [°C]
             Real TairK = TairC + 273.16_rt; // Air temperature [K]
             Real Hair = qair_arr(i,j,0);   // Specific humidity [kg/kg] or RH [fraction]
+            Real srflux = srflx_arr(i,j,0); // Shortwave radiation flux [W/m²]
+            Real cloud = cloud_arr(i,j,0);  // Cloud cover fraction [0-1]
 
             // Input bulk parametrization fields
             Real wind_mag = std::sqrt(uwind(i,j,0)*uwind(i,j,0) + vwind(i,j,0) * vwind(i,j,0)) + eps;


### PR DESCRIPTION
I've added spatial variability capability for the salt flux variables in the bulk flux calculations. Additionally added documentation to reflect these updates and how to specify constant or spatially varying values from netcdf. 