### PR TITLE
Adds outgoing longwave parameterization

### DIFF
--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -411,6 +411,7 @@ void REMORA::resize_stuff(int lev)
     vec_btflux.resize(lev+1);
     vec_stflux.resize(lev+1);
     vec_lrflx.resize(lev+1);
+    vec_longwave_down.resize(lev+1);
     vec_lhflx.resize(lev+1);
     vec_shflx.resize(lev+1);
     vec_rain.resize(lev+1);
@@ -640,6 +641,7 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
         vec_qair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, specific humidity
         vec_Pair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, air pressure
         vec_srflx[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, shortwave radiation flux
+        vec_longwave_down[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, downward longwave radiation flux
         vec_cloud[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, cloud cover fraction
         vec_EminusP[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, evaporation minus precipitation
         vec_alpha[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -322,11 +322,13 @@ public:
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_qair;
     /** \brief Air pressure [mb], defined at rho-points */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_Pair;
+
     /** \brief Shortwave radiation flux [W/m²], defined at rho-points */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_srflx;
-
     /** \brief longwave radiation */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_lrflx;
+    /** \brief Downward longwave radiation */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_longwave_down;
     /** \brief latent heat flux */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_lhflx;
     /** \brief sensible heat flux */
@@ -538,6 +540,7 @@ public:
                       amrex::MultiFab* mf_qair,
                       amrex::MultiFab* mf_Pair,
                       amrex::MultiFab* mf_srflx,
+                      amrex::MultiFab* mf_longwave_down,
                       amrex::MultiFab* mf_evap,
                       amrex::MultiFab* mf_sustr,
                       amrex::MultiFab* mf_svstr,
@@ -1107,6 +1110,8 @@ private:
     NCTimeSeries* Pair_data_from_file;
     /** \brief Data container for shortwave radiation flux read from file */
     NCTimeSeries* srflx_data_from_file;
+    /** \brief Data container for downward longwave radiation flux read from file */
+    NCTimeSeries* longwave_down_data_from_file;
     /** \brief Data container for precipitation rate read from file */
     NCTimeSeries* rain_data_from_file;
     /** \brief Data container for cloud cover fraction read from file */

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -780,7 +780,6 @@ REMORA::set_wind(int lev)
 #endif
     }
 }
-
 /**
  * @param[in   ] lev    level to operate on
  */
@@ -924,6 +923,13 @@ REMORA::init_only (int lev, Real time)
         svstr_data_from_file = new NCTimeSeries(nc_frc_file, "svstr", frc_time_varname, geom[lev].Domain(),vec_svstr[lev].get(), true, false);
         sustr_data_from_file->Initialize();
         svstr_data_from_file->Initialize();
+    }
+    if (solverChoice.longwave_down_from_netcdf) {
+        if (nc_frc_file.empty()) {
+            amrex::Error("NetCDF forcing file name must be provided via input for longwave radiation");
+        }
+        longwave_down_data_from_file = new NCTimeSeries(nc_frc_file, "longwave_down", frc_time_varname, geom[lev].Domain(), vec_longwave_down[lev].get(), true, false);
+        longwave_down_data_from_file->Initialize();
     }
 
     if (solverChoice.do_rivers) {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -757,6 +757,11 @@ REMORA::set_wind(int lev)
             FillPatch(lev, t_old[lev], *vec_srflx[lev], GetVecOfPtrs(vec_srflx),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
+        if (solverChoice.longwave_down_from_netcdf) {
+            longwave_down_data_from_file->update_interpolated_to_time(t_old[lev]);
+            FillPatch(lev, t_old[lev], *vec_longwave_down[lev], GetVecOfPtrs(vec_longwave_down),
+                      BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
+        }
         if (solverChoice.rain_from_netcdf) {
             rain_data_from_file->update_interpolated_to_time(t_old[lev]);
             FillPatch(lev, t_old[lev], *vec_rain[lev], GetVecOfPtrs(vec_rain),

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -198,8 +198,6 @@ struct SolverChoice {
         pp.queryAdd("blk_ZW",blk_ZW);
         pp.queryAdd("eminusp",eminusp);
         pp.queryAdd("eminusp_correct_ssh",eminusp_correct_ssh);
-        
-
         // Control flags for loading atmospheric variables from NetCDF
         pp.queryAdd("Tair_from_netcdf",Tair_from_netcdf);
         pp.queryAdd("qair_from_netcdf",qair_from_netcdf);
@@ -215,8 +213,6 @@ struct SolverChoice {
         if (eminusp and !bulk_fluxes) {
             amrex::Abort("Evaporation minus precipitation (E-P) requires bulk flux parametrizations (remora.bulk_fluxes=true)");
         }
-
-        
 
         //Read in linear eos parameters
         //Grid stretching

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -189,6 +189,8 @@ struct SolverChoice {
         pp.queryAdd("air_humidity",Hair);
         pp.queryAdd("surface_radiation_flux",srflux);
         pp.queryAdd("srflx_from_netcdf",srflx_from_netcdf);
+        pp.queryAdd("longwave_down", longwave_down);
+        pp.queryAdd("longwave_down_from_netcdf",longwave_down_from_netcdf);
         pp.queryAdd("cloud",cloud);
         pp.queryAdd("rain",rain);
         pp.queryAdd("blk_ZQ",blk_ZQ);
@@ -196,6 +198,7 @@ struct SolverChoice {
         pp.queryAdd("blk_ZW",blk_ZW);
         pp.queryAdd("eminusp",eminusp);
         pp.queryAdd("eminusp_correct_ssh",eminusp_correct_ssh);
+        
 
         // Control flags for loading atmospheric variables from NetCDF
         pp.queryAdd("Tair_from_netcdf",Tair_from_netcdf);
@@ -212,6 +215,8 @@ struct SolverChoice {
         if (eminusp and !bulk_fluxes) {
             amrex::Abort("Evaporation minus precipitation (E-P) requires bulk flux parametrizations (remora.bulk_fluxes=true)");
         }
+
+        
 
         //Read in linear eos parameters
         //Grid stretching
@@ -562,16 +567,19 @@ struct SolverChoice {
     bool        bulk_fluxes           = false;
     bool        do_temp_flux        = false;
     bool        do_salt_flux        = false;
+    bool        longwave_down          = false;
 
     // Control flags for loading atmospheric variables from NetCDF
     bool        Tair_from_netcdf      = false;
     bool        qair_from_netcdf      = false;
     bool        Pair_from_netcdf      = false;
     bool        srflx_from_netcdf     = false;
+    bool        longwave_down_from_netcdf          = false;
     bool        rain_from_netcdf      = false;
     bool        cloud_from_netcdf     = false;
     bool        EminusP_from_netcdf   = false;
     bool        qair_is_percent       = false;
+
 
     bool        do_rivers             = false;
     bool        do_rivers_temp        = true;

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -565,9 +565,9 @@ struct SolverChoice {
     bool        use_barotropic        = true;
 
     bool        bulk_fluxes           = false;
-    bool        do_temp_flux        = false;
-    bool        do_salt_flux        = false;
-    bool        longwave_down          = false;
+    bool        do_temp_flux          = false;
+    bool        do_salt_flux          = false;
+    bool        longwave_down         = false;
 
     // Control flags for loading atmospheric variables from NetCDF
     bool        Tair_from_netcdf      = false;

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -97,7 +97,6 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             Real TseaK = cons(i,j,N,Temp_comp) + 273.16_rt;
 
             // Initialize
-            Real cff = 0.0_rt;
             Real delTc = 0.0_rt;
             Real delQc = 0.0_rt;
 
@@ -106,12 +105,12 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             Real Taur = 0.0_rt;
             Taux(i,j,0) = 0.0_rt;
             Tauy(i,j,0) = 0.0_rt;
-
+            Real LRad;
 
             /*-----------------------------------------------------------------------
                Compute outward or net longwave radiation (W/m2), LRad.
              -----------------------------------------------------------------------
-               If given downward longwave radiation, compute net longwave radiation as 
+               If given downward longwave radiation, compute net longwave radiation as
                Ldown - Lemit, where Lemit is computed from the model SST and an emissivity.
                Or use Berliand (1952) formula to calculate net longwave radiation.
                The equation for saturation vapor pressure is from Gill (Atmosphere-
@@ -120,19 +119,11 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
                1.0 at poles to 0.5 at the Equator).
 
             */
-            Real LRad;
-            // If given downward longwave radiation, compute net longwave radiation as 
-            // Ldown - Lemit, where Lemit is computed from the model SST and an assumed emissivity.
-
             if (use_longwave_down) {
-
                 Real Ldown = longwave_down_arr(i,j,0);
                 Real Lemit = emmiss * StefBo * std::pow(TseaK,4);
-
                 LRad = Ldown - Lemit;
-
             } else {
-
                 // Original Berliand parameterization
                 Real cff=(0.7859_rt+0.03477_rt*TairC)/(1.0_rt+0.00412_rt*TairC);
                 Real e_sat=std::pow(10.0_rt,cff);
@@ -145,7 +136,6 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
                         (1.0_rt-0.6823_rt*cloud*cloud)+
                         cff2*4.0_rt*(TseaK-TairK));
             }
-
            /*
             -----------------------------------------------------------------------
               Compute specific humidities (kg/kg).
@@ -222,7 +212,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
 
             Real VisAir=1.326E-5_rt*(1.0_rt+TairC*(6.542E-3_rt+TairC*
                                      (8.301E-6_rt-4.84E-9_rt*TairC)));
-\
+
             //  Compute latent heat of vaporization (J/kg) at sea surface, Hlv.
 
             Real Hlv = (2.501_rt-0.00237_rt*cons(i,j,N,Temp_comp))*1.0e6_rt;

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -126,7 +126,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
                 LRad = Ldown - Lemit;
             } else {
                 // Original Berliand parameterization
-                Real cff=(0.7859_rt+0.03477_rt*TairC)/(1.0_rt+0.00412_rt*TairC);
+                cff=(0.7859_rt+0.03477_rt*TairC)/(1.0_rt+0.00412_rt*TairC);
                 Real e_sat=std::pow(10.0_rt,cff);
                 Real vap_p=e_sat*RH;
                 Real cff2=TairK*TairK*TairK;

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -11,6 +11,7 @@ using namespace amrex;
  * @param[in   ] mf_qair        specific humidity [kg/kg]
  * @param[in   ] mf_Pair        air pressure [mb]
  * @param[in   ] mf_srflx       shortwave radiation flux [W/m²]
+ * @param[in   ] mf_longwave_down longwave radiation flux [W/m²]
  * @param[inout] mf_evap        evaporation rate
  * @param[  out] mf_sustr       u-direction surface momentum stress
  * @param[  out] mf_svstr       v-direction surface momentum stress
@@ -24,6 +25,7 @@ void
 REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* mf_vwind,
                      MultiFab* mf_Tair, MultiFab* mf_qair, MultiFab* mf_Pair,
                      MultiFab* mf_srflx,
+                     MultiFab* mf_longwave_down,
                      MultiFab* mf_evap, MultiFab* mf_sustr, MultiFab* mf_svstr,
                      MultiFab* mf_stflux, MultiFab* mf_lrflx, MultiFab* mf_lhflx,
                      MultiFab* mf_shflx,
@@ -44,6 +46,10 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Array4<Real const> const& qair_arr = mf_qair->const_array(mfi);
         Array4<Real const> const& Pair_arr = mf_Pair->const_array(mfi);
         Array4<Real const> const& srflx_arr = mf_srflx->const_array(mfi);
+        Array4<Real const> longwave_down_arr;
+        if (mf_longwave_down != nullptr) {
+            longwave_down_arr = mf_longwave_down->const_array(mfi);
+        }
         Array4<Real const> const& cons = mf_cons->const_array(mfi);
         Array4<Real> const& sustr = mf_sustr->array(mfi);
         Array4<Real> const& svstr = mf_svstr->array(mfi);
@@ -67,6 +73,8 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Real blk_ZT = solverChoice.blk_ZT;
         Real blk_ZW = solverChoice.blk_ZW;
 
+        bool use_longwave_down = solverChoice.longwave_down;
+
         Real eps = 1e-20_rt;
 
         Box bx = mfi.tilebox();
@@ -80,6 +88,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             Real TairC = Tair_arr(i,j,0);  // Air temperature [°C]
             Real TairK = TairC + 273.16_rt; // Air temperature [K]
             Real Hair = qair_arr(i,j,0);   // Specific humidity [kg/kg] or RH [fraction]
+            Real RH = Hair;
             Real srflux = srflx_arr(i,j,0); // Shortwave radiation flux [W/m²]
             Real cloud = cloud_arr(i,j,0);  // Cloud cover fraction [0-1]
 
@@ -88,6 +97,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             Real TseaK = cons(i,j,N,Temp_comp) + 273.16_rt;
 
             // Initialize
+            Real cff = 0.0_rt;
             Real delTc = 0.0_rt;
             Real delQc = 0.0_rt;
 
@@ -99,26 +109,42 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
 
 
             /*-----------------------------------------------------------------------
-               Compute net longwave radiation (W/m2), LRad.
+               Compute outward or net longwave radiation (W/m2), LRad.
              -----------------------------------------------------------------------
-
-               Use Berliand (1952) formula to calculate net longwave radiation.
+               If given downward longwave radiation, compute net longwave radiation as 
+               Ldown - Lemit, where Lemit is computed from the model SST and an emissivity.
+               Or use Berliand (1952) formula to calculate net longwave radiation.
                The equation for saturation vapor pressure is from Gill (Atmosphere-
                Ocean Dynamics, pp 606). Here the coefficient in the cloud term
                is assumed constant, but it is a function of latitude varying from
                1.0 at poles to 0.5 at the Equator).
 
             */
-            Real RH = Hair;
-            Real cff=(0.7859_rt+0.03477_rt*TairC)/(1.0_rt+0.00412_rt*TairC);
-            Real e_sat=std::pow(10.0_rt,cff);   // saturation vapor pressure (hPa or mbar)
-            Real vap_p=e_sat*RH;       // water vapor pressure (hPa or mbar)
-            Real cff2=TairK*TairK*TairK;
-            Real cff1=cff2*TairK;
-            Real LRad=-emmiss*StefBo*
-                               (cff1*(0.39_rt-0.05_rt*std::sqrt(vap_p))*
-                                     (1.0_rt-0.6823_rt*cloud*cloud)+
-                                cff2*4.0_rt*(TseaK-TairK));
+            Real LRad;
+            // If given downward longwave radiation, compute net longwave radiation as 
+            // Ldown - Lemit, where Lemit is computed from the model SST and an assumed emissivity.
+
+            if (use_longwave_down) {
+
+                Real Ldown = longwave_down_arr(i,j,0);
+                Real Lemit = emmiss * StefBo * std::pow(TseaK,4);
+
+                LRad = Ldown - Lemit;
+
+            } else {
+
+                // Original Berliand parameterization
+                Real cff=(0.7859_rt+0.03477_rt*TairC)/(1.0_rt+0.00412_rt*TairC);
+                Real e_sat=std::pow(10.0_rt,cff);
+                Real vap_p=e_sat*RH;
+                Real cff2=TairK*TairK*TairK;
+                Real cff1=cff2*TairK;
+
+                LRad=-emmiss*StefBo*
+                    (cff1*(0.39_rt-0.05_rt*std::sqrt(vap_p))*
+                        (1.0_rt-0.6823_rt*cloud*cloud)+
+                        cff2*4.0_rt*(TseaK-TairK));
+            }
 
            /*
             -----------------------------------------------------------------------

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -99,6 +99,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             // Initialize
             Real delTc = 0.0_rt;
             Real delQc = 0.0_rt;
+            Real cff = 0.0_rt;
 
             Real LHeat = lhflx(i,j,0) * Hscale;
             Real SHeat = shflx(i,j,0) * Hscale;

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -180,10 +180,15 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
     const Real Cdb_min = solverChoice.Cdb_min;
     const Real Cdb_max = solverChoice.Cdb_max;
 
+    MultiFab* lw_ptr = nullptr;
+
+    if (solverChoice.longwave_down_from_netcdf)
+        lw_ptr = vec_longwave_down[lev].get();
     if (solverChoice.bulk_fluxes) {
         bulk_fluxes(lev, cons_old[lev],vec_uwind[lev].get(),vec_vwind[lev].get(),
                     vec_Tair[lev].get(),vec_qair[lev].get(),vec_Pair[lev].get(),
                     vec_srflx[lev].get(),
+                    lw_ptr,
                     vec_evap[lev].get(),
                     vec_sustr[lev].get(),vec_svstr[lev].get(),vec_stflux[lev].get(),
                     vec_lrflx[lev].get(),vec_lhflx[lev].get(),vec_shflx[lev].get(),N);


### PR DESCRIPTION
Adds a stealth option to give REMORA downward longwave radiation as a netcdf file at runtime and parameterize outgoing longwave based on model SST. This is the equivalent of adding ```#LONGWAVE_OUT``` to the ROMS header file. [This](https://www.myroms.org/forum/viewtopic.php?p=25453#p25453) post can explain more details, but this is often more accurate than the Berliand (1952) formulation. 

Only supported when external netcdf files are read in. Did not build the infrastructure to set up with an analytical option. Assumed that for analytical cases, you would use the Berliand formulation (because realism is not the point). Note that if downward is given, clouds are not used in bulk fluxes, but are still required in the forcing file to avoid a seg fault at run time. 

To use, add:
```
remora.longwave_down      = true
remora.longwave_down_from_netcdf = true
```
to the inputs file. 

All regression tests passed. However, because REMORA does not output the surface forcing or heat fluxes (I think, could be incorrect?), it is difficult to compare solutions. A separate PR is needed to add the heat budget terms + surface forcing. For this reason, I am holding off on editing the docs. 