### PR TITLE
Outputs surface forcing to netcdf files

### DIFF
--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -416,6 +416,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
         ncf.var("svstr").put_attr("field","surface v-momentum stress, scalar, series");
 
         if (solverChoice.output_forcing) {
+            // Surface air temperature (Celsius)
             ncf.def_var("Tair", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
             ncf.var("Tair").put_attr("long_name","surface air temperature");
             ncf.var("Tair").put_attr("units","Celsius");
@@ -425,6 +426,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
             ncf.var("Tair").put_attr("coordinates","x_rho y_rho ocean_time");
             ncf.var("Tair").put_attr("field","Tair, scalar, series");
 
+            // Surface air pressure (Pascal)
             ncf.def_var("Pair", ncutils::NCDType::Real,{ nt_name, ny_r_name, nx_r_name });
             ncf.var("Pair").put_attr("long_name","surface air pressure");
             ncf.var("Pair").put_attr("units","Pascal");
@@ -433,6 +435,86 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
             ncf.var("Pair").put_attr("location","face");
             ncf.var("Pair").put_attr("coordinates","x_rho y_rho ocean_time");
             ncf.var("Pair").put_attr("field","Pair, scalar, series");
+
+            // Surface net heat flux (W/m2)
+            ncf.def_var("qnet", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("qnet").put_attr("long_name","surface net heat flux");
+            ncf.var("qnet").put_attr("units","watt meter-2");
+            ncf.var("qnet").put_attr("time","ocean_time");
+            ncf.var("qnet").put_attr("grid","grid");
+            ncf.var("qnet").put_attr("location","face");
+            ncf.var("qnet").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("qnet").put_attr("field","surface heat flux, scalar, series");
+
+            // Surface net salt flux (kinematic)
+            ncf.def_var("ssflux", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("ssflux").put_attr("long_name","kinematic surface net salt flux, SALT*(E-P)/rhow");
+            ncf.var("ssflux").put_attr("units","meter second-1");
+            ncf.var("ssflux").put_attr("time","ocean_time");
+            ncf.var("ssflux").put_attr("grid","grid");
+            ncf.var("ssflux").put_attr("location","face");
+            ncf.var("ssflux").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("ssflux").put_attr("field","surface net salt flux, scalar, series");
+
+            // Latent heat flux (W/m2)
+            ncf.def_var("latent", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("latent").put_attr("long_name","net latent heat flux");
+            ncf.var("latent").put_attr("units","watt meter-2");
+            ncf.var("latent").put_attr("time","ocean_time");
+            ncf.var("latent").put_attr("grid","grid");
+            ncf.var("latent").put_attr("location","face");
+            ncf.var("latent").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("latent").put_attr("field","latent heat flux, scalar, series");
+
+            // Sensible heat flux (W/m2)
+            ncf.def_var("sensible", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("sensible").put_attr("long_name","net sensible heat flux");
+            ncf.var("sensible").put_attr("units","watt meter-2");
+            ncf.var("sensible").put_attr("time","ocean_time");
+            ncf.var("sensible").put_attr("grid","grid");
+            ncf.var("sensible").put_attr("location","face");
+            ncf.var("sensible").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("sensible").put_attr("field","sensible heat flux, scalar, series");
+
+            // Longwave radiation (W/m2)
+            ncf.def_var("lwrad", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("lwrad").put_attr("long_name","net longwave radiation flux");
+            ncf.var("lwrad").put_attr("units","watt meter-2");
+            ncf.var("lwrad").put_attr("time","ocean_time");
+            ncf.var("lwrad").put_attr("grid","grid");
+            ncf.var("lwrad").put_attr("location","face");
+            ncf.var("lwrad").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("lwrad").put_attr("field","longwave radiation, scalar, series");
+
+            // Shortwave radiation (W/m2)
+            ncf.def_var("swrad", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("swrad").put_attr("long_name","solar shortwave radiation flux");
+            ncf.var("swrad").put_attr("units","watt meter-2");
+            ncf.var("swrad").put_attr("time","ocean_time");
+            ncf.var("swrad").put_attr("grid","grid");
+            ncf.var("swrad").put_attr("location","face");
+            ncf.var("swrad").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("swrad").put_attr("field","shortwave radiation, scalar, series");
+
+            // Evaporation rate (kg m-2 s-1)
+            ncf.def_var("evaporation", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("evaporation").put_attr("long_name","evaporation rate");
+            ncf.var("evaporation").put_attr("units","kilogram meter-2 second-1");
+            ncf.var("evaporation").put_attr("time","ocean_time");
+            ncf.var("evaporation").put_attr("grid","grid");
+            ncf.var("evaporation").put_attr("location","face");
+            ncf.var("evaporation").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("evaporation").put_attr("field","evaporation, scalar, series");
+
+            // Rain rate (kg m-2 s-1)
+            ncf.def_var("rain", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("rain").put_attr("long_name","rain fall rate");
+            ncf.var("rain").put_attr("units","kilogram meter-2 second-1");
+            ncf.var("rain").put_attr("time","ocean_time");
+            ncf.var("rain").put_attr("grid","grid");
+            ncf.var("rain").put_attr("location","face");
+            ncf.var("rain").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("rain").put_attr("field","rain, scalar, series");
         }
         // Right now this is hard-wired to {temp, salt, tracer, u, v}
         ncf.put_attr("space_dimension", std::vector<int> { AMREX_SPACEDIM });
@@ -750,6 +832,9 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
                         local_nx });
             }
             if (solverChoice.output_forcing) {
+
+                const Real Hscale = solverChoice.rho0 * Cp;
+                // Tair
                 {
                     FArrayBox tmp_Tair;
                     tmp_Tair.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
@@ -759,7 +844,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
                     auto nc_plot_var = ncf.var("Tair");
                     nc_plot_var.put(tmp_Tair.dataPtr(), { local_start_nt, local_start_y, local_start_x }, { local_nt, local_ny, local_nx });
                 }
-
+                // Pair
                 {
                     FArrayBox tmp_Pair;
                     tmp_Pair.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
@@ -768,6 +853,127 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
 
                     auto nc_plot_var = ncf.var("Pair");
                     nc_plot_var.put(tmp_Pair.dataPtr(), { local_start_nt, local_start_y, local_start_x }, { local_nt, local_ny, local_nx });
+                }
+                // qnet  (stored °C m/s → write W/m²)
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+
+                    // Copy stflux Temp component
+                    tmp.template copy<RunOn::Device>(
+                        (*vec_stflux[lev])[mfi.index()],
+                        Temp_comp,  // source component
+                        0,          // dest component
+                        1           // number of comps
+                    );
+
+                    Gpu::streamSynchronize();
+
+                    // Convert °C·m/s → W/m²
+                    tmp.mult(Hscale);
+
+                    auto nc_var = ncf.var("qnet");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // ssflux = surface net freshwater flux (kg/m²/s converted to m/s)
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+
+                    // Copy stflux Salt component
+                    tmp.template copy<RunOn::Device>(
+                        (*vec_stflux[lev])[mfi.index()],
+                        Salt_comp, // source component
+                        0,         // destination component
+                        1          // number of components
+                    );
+
+                    Gpu::streamSynchronize();
+
+                    auto nc_var = ncf.var("ssflux");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // latent  (stored °C m/s → write W/m²)
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_lhflx[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    tmp.mult(Hscale);  // convert to W/m²
+
+                    auto nc_var = ncf.var("latent");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // sensible  (stored °C m/s → write W/m²)
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_shflx[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    tmp.mult(Hscale);  // convert to W/m²
+
+                    auto nc_var = ncf.var("sensible");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // lwrad  (stored °C m/s → write W/m²)
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_lrflx[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    tmp.mult(Hscale);  // convert to W/m²
+
+                    auto nc_var = ncf.var("lwrad");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // swrad, note this is stored explicitly as W/m², not degC m/s in REMORA.bulk_flux.cpp
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_srflx[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    auto nc_var = ncf.var("swrad");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // evaporation
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_evap[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    auto nc_var = ncf.var("evaporation");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
+                }
+                // rain
+                {
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_rain[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    auto nc_var = ncf.var("rain");
+                    nc_var.put(tmp.dataPtr(),
+                            { local_start_nt, local_start_y, local_start_x },
+                            { local_nt,       local_ny,       local_nx });
                 }
             }
 
@@ -781,7 +987,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
                 nc_plot_var.put(tmp_temp.dataPtr(), { local_start_nt, local_start_z, local_start_y, local_start_x }, { local_nt,
                         local_nz, local_ny, local_nx });
             }
-
             {
                 FArrayBox tmp_salt;
                 tmp_salt.resize(tmp_bx, 1, amrex::The_Pinned_Arena());

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -415,6 +415,25 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
         ncf.var("svstr").put_attr("coordinates","x_v y_v ocean_time");
         ncf.var("svstr").put_attr("field","surface v-momentum stress, scalar, series");
 
+        if (solverChoice.output_forcing) {
+            ncf.def_var("Tair", ncutils::NCDType::Real, {nt_name, ny_r_name, nx_r_name });
+            ncf.var("Tair").put_attr("long_name","surface air temperature");
+            ncf.var("Tair").put_attr("units","Celsius");
+            ncf.var("Tair").put_attr("time","ocean_time");
+            ncf.var("Tair").put_attr("grid","grid");
+            ncf.var("Tair").put_attr("location","face");
+            ncf.var("Tair").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("Tair").put_attr("field","Tair, scalar, series");
+
+            ncf.def_var("Pair", ncutils::NCDType::Real,{ nt_name, ny_r_name, nx_r_name });
+            ncf.var("Pair").put_attr("long_name","surface air pressure");
+            ncf.var("Pair").put_attr("units","Pascal");
+            ncf.var("Pair").put_attr("time","ocean_time");
+            ncf.var("Pair").put_attr("grid","grid");
+            ncf.var("Pair").put_attr("location","face");
+            ncf.var("Pair").put_attr("coordinates","x_rho y_rho ocean_time");
+            ncf.var("Pair").put_attr("field","Pair, scalar, series");
+        }
         // Right now this is hard-wired to {temp, salt, tracer, u, v}
         ncf.put_attr("space_dimension", std::vector<int> { AMREX_SPACEDIM });
 //        ncf.put_attr("current_time", std::vector<double> { time });
@@ -729,6 +748,27 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, bool write_head
                 auto nc_plot_var = ncf.var("zeta");
                 nc_plot_var.put(tmp_zeta.dataPtr(), { local_start_nt, local_start_y, local_start_x }, { local_nt, local_ny,
                         local_nx });
+            }
+            if (solverChoice.output_forcing) {
+                {
+                    FArrayBox tmp_Tair;
+                    tmp_Tair.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp_Tair.template copy<RunOn::Device>((*vec_Tair[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    auto nc_plot_var = ncf.var("Tair");
+                    nc_plot_var.put(tmp_Tair.dataPtr(), { local_start_nt, local_start_y, local_start_x }, { local_nt, local_ny, local_nx });
+                }
+
+                {
+                    FArrayBox tmp_Pair;
+                    tmp_Pair.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp_Pair.template copy<RunOn::Device>((*vec_Pair[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
+
+                    auto nc_plot_var = ncf.var("Pair");
+                    nc_plot_var.put(tmp_Pair.dataPtr(), { local_start_nt, local_start_y, local_start_x }, { local_nt, local_ny, local_nx });
+                }
             }
 
             {

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -184,6 +184,8 @@ struct SolverChoice {
             do_salt_flux = true;
             do_temp_flux = true;
         }
+        // Outputs forcing variables if true
+        pp.queryAdd("output_forcing", output_forcing);
         pp.queryAdd("air_pressure",Pair);
         pp.queryAdd("air_temperature",Tair);
         pp.queryAdd("air_humidity",Hair);
@@ -560,6 +562,7 @@ struct SolverChoice {
     bool        use_barotropic        = true;
 
     bool        bulk_fluxes           = false;
+    bool        output_forcing        = false;
     bool        do_temp_flux        = false;
     bool        do_salt_flux        = false;
 


### PR DESCRIPTION
Adds a QOL stealth feature to output 2D surface forcing to netcdf files. Activated if ```remora.output_forcing = true```. This is to avoid additional post-processing for the user because the model output and forcing are often not colocated in time. Without this feature, it is not possible to construct a heat budget with model output. 

Example output below, verified using the boundary layer test case.  
```
        double Tair(ocean_time, eta_rho, xi_rho) ;
                Tair:long_name = "surface air temperature" ;
                Tair:units = "Celsius" ;
                Tair:time = "ocean_time" ;
                Tair:grid = "grid" ;
                Tair:location = "face" ;
                Tair:coordinates = "x_rho y_rho ocean_time" ;
                Tair:field = "Tair, scalar, series" ;
        double Pair(ocean_time, eta_rho, xi_rho) ;
                Pair:long_name = "surface air pressure" ;
                Pair:units = "Pascal" ;
                Pair:time = "ocean_time" ;
                Pair:grid = "grid" ;
                Pair:location = "face" ;
                Pair:coordinates = "x_rho y_rho ocean_time" ;
                Pair:field = "Pair, scalar, series" ;
        double qnet(ocean_time, eta_rho, xi_rho) ;
                qnet:long_name = "surface net heat flux" ;
                qnet:units = "watt meter-2" ;
                qnet:time = "ocean_time" ;
                qnet:grid = "grid" ;
                qnet:location = "face" ;
                qnet:coordinates = "x_rho y_rho ocean_time" ;
                qnet:field = "surface heat flux, scalar, series" ;
        double ssflux(ocean_time, eta_rho, xi_rho) ;
                ssflux:long_name = "kinematic surface net salt flux, SALT*(E-P)/rhow" ;
                ssflux:units = "meter second-1" ;
                ssflux:time = "ocean_time" ;
                ssflux:grid = "grid" ;
                ssflux:location = "face" ;
                ssflux:coordinates = "x_rho y_rho ocean_time" ;
                ssflux:field = "surface net salt flux, scalar, series" ;
        double latent(ocean_time, eta_rho, xi_rho) ;
                latent:long_name = "net latent heat flux" ;
                latent:units = "watt meter-2" ;
                latent:time = "ocean_time" ;
                latent:grid = "grid" ;
                latent:location = "face" ;
                latent:coordinates = "x_rho y_rho ocean_time" ;
                latent:field = "latent heat flux, scalar, series" ;
        double sensible(ocean_time, eta_rho, xi_rho) ;
                sensible:long_name = "net sensible heat flux" ;
                sensible:units = "watt meter-2" ;
                sensible:time = "ocean_time" ;
                sensible:grid = "grid" ;
                sensible:location = "face" ;
                sensible:coordinates = "x_rho y_rho ocean_time" ;
                sensible:field = "sensible heat flux, scalar, series" ;
        double lwrad(ocean_time, eta_rho, xi_rho) ;
                lwrad:long_name = "net longwave radiation flux" ;
                lwrad:units = "watt meter-2" ;
                lwrad:time = "ocean_time" ;
                lwrad:grid = "grid" ;
                lwrad:location = "face" ;
                lwrad:coordinates = "x_rho y_rho ocean_time" ;
                lwrad:field = "longwave radiation, scalar, series" ;
        double swrad(ocean_time, eta_rho, xi_rho) ;
                swrad:long_name = "solar shortwave radiation flux" ;
                swrad:units = "watt meter-2" ;
                swrad:time = "ocean_time" ;
                swrad:grid = "grid" ;
                swrad:location = "face" ;
                swrad:coordinates = "x_rho y_rho ocean_time" ;
                swrad:field = "shortwave radiation, scalar, series" ;
        double evaporation(ocean_time, eta_rho, xi_rho) ;
                evaporation:long_name = "evaporation rate" ;
                evaporation:units = "kilogram meter-2 second-1" ;
                evaporation:time = "ocean_time" ;
                evaporation:grid = "grid" ;
                evaporation:location = "face" ;
                evaporation:coordinates = "x_rho y_rho ocean_time" ;
                evaporation:field = "evaporation, scalar, series" ;
        double rain(ocean_time, eta_rho, xi_rho) ;
                rain:long_name = "rain fall rate" ;
                rain:units = "kilogram meter-2 second-1" ;
                rain:time = "ocean_time" ;
                rain:grid = "grid" ;
                rain:location = "face" ;
                rain:coordinates = "x_rho y_rho ocean_time" ;
                rain:field = "rain, scalar, series" ;
```
To replicate, modify ```inputs``` to:
```
remora.max_step = 1000

# PLOTFILES
remora.plotfile_type = netcdf
remora.output_forcing = true
```
and compare 
```
remora.air_temperature = 23.567
remora.air_pressure = 1013.48
remora.rain = 0.002
```
with netcdf files. Code below to analyze run. 
```
import xarray as xr
import matplotlib.pyplot as plt

path = '/pscratch/sd/d/dylan617/REMORA/add_forcing_outputs/Exec/BoundaryLayer/plt_his_d01.nc'
ds = xr.open_dataset(path)

fig,ax=plt.subplots(1,1,figsize=(9,2.75),dpi=200)

# Tair, Pair, and rain match input file, not shown
# plt.plot(ds.Tair.mean(axis=(1,2)))
# plt.plot(ds.Pair.mean(axis=(1,2)))
# plt.plot(ds.rain.mean(axis=(1,2)))

plt.plot(ds.qnet.mean(axis=(1,2))[1:], label = 'Qnet')
plt.plot((ds.latent + ds.sensible + ds.swrad + ds.lwrad ).mean(axis=(1,2))[1:], label = r'$\Sigma$ All')
plt.plot(ds.lwrad.mean(axis=(1,2))[1:], label = 'longwave')
plt.plot(ds.swrad.mean(axis=(1,2))[1:], label = 'shortwave')
plt.plot(ds.latent.mean(axis=(1,2))[1:], label = 'latent')
plt.plot(ds.sensible.mean(axis=(1,2))[1:], label = 'sensible')
plt.legend()
plt.title('Spatially-averaged heat budget, boundary layer test')
plt.ylabel('W/m$^2$')
```
Spatially averaged heat budget, confirms that qnet is equal to the sum of components and all values are reasonable. 
<img width="1573" height="553" alt="image" src="https://github.com/user-attachments/assets/8b1ceb2e-5e42-4746-b9f1-aa6217e268d0" />