### PR TITLE
Interpolation from level0 to higher levels

### DIFF
--- a/Source/IO/REMORA_NCTimeSeries.H
+++ b/Source/IO/REMORA_NCTimeSeries.H
@@ -4,10 +4,9 @@
 #ifdef REMORA_USE_NETCDF
 
 #include <string>
+#include <memory>
 
 #include <AMReX_AmrCore.H>
-
-#include <REMORA.H>
 
 /** \brief A class to hold and interpolate time series data read from a NetCDF file
  *
@@ -28,14 +27,21 @@ class NCTimeSeries
         /** \brief Read in time array from file and allocate data arrays */
         void Initialize ();
 
-        /** \brief Calculate interpolated values at time, reading in data as necessary */
-        void update_interpolated_to_time (amrex::Real time);
+        /** \brief Calculate interpolated values at time and fill data for level lev */
+        void update_interpolated_to_time (amrex::Real time, int lev,
+                                          amrex::MultiFab* mf_lev,
+                                          const amrex::Vector<amrex::Geometry>& geom,
+                                          const amrex::Vector<amrex::IntVect>& ref_ratio);
 
-        /** Container for interpolated data; Only used if save_interpolated == true */
-        amrex::MultiFab* mf_interpolated;
+        /** \brief Access interpolated data saved for a specific level */
+        const amrex::MultiFab* get_interpolated_mf (int lev) const;
     private:
         /** \brief Read in data from file at time index itime and fill into mf */
         void read_in_at_time (amrex::MultiFab* mf, int itime);
+
+        /** \brief Build cumulative refinement ratio from level 0 to lev */
+        amrex::IntVect cumulative_ref_ratio (int lev,
+                                             const amrex::Vector<amrex::IntVect>& ref_ratio) const;
 
         /// File name to read from
         std::string file_name;
@@ -65,6 +71,10 @@ class NCTimeSeries
         amrex::MultiFab* mf_before;
         /// Multifab to store data at time_after
         amrex::MultiFab* mf_after;
+        /// Multifab storing temporally interpolated data on level 0
+        amrex::MultiFab* mf_interp_lev0;
+        /// Interpolated data on each requested AMR level if save_interpolated=true
+        amrex::Vector<std::unique_ptr<amrex::MultiFab>> mf_interpolated_lev;
         /** Pointer to REMORA data that corresponds to the variable being interpolated.
          * Filled by update_interpolated_to_time if save_interpolated==false. Otherwise,
          * just used for getting box array, nodality, and distribution mapping */

--- a/Source/IO/REMORA_NCTimeSeries.cpp
+++ b/Source/IO/REMORA_NCTimeSeries.cpp
@@ -1,6 +1,8 @@
 #include "REMORA_NCTimeSeries.H"
 #include "REMORA_NCFile.H"
 
+#include "AMReX_FillPatchUtil.H"
+#include "AMReX_Interpolater.H"
 #include "AMReX_ParallelDescriptor.H"
 
 #include <string>
@@ -79,12 +81,10 @@ void NCTimeSeries::Initialize() {
     amrex::ParallelDescriptor::Bcast(ocean_times.data(), ocean_times.size(), ioproc);
 
     // Initialize MultiFabs
-    // This assumes that the level 0 distribution map and box array won't
+    // NetCDF data is always read and temporally interpolated on level 0.
     mf_before = new amrex::MultiFab(mf_var->boxArray(), mf_var->DistributionMap(), 1, mf_var->nGrowVect());
     mf_after = new amrex::MultiFab(mf_var->boxArray(), mf_var->DistributionMap(), 1, mf_var->nGrowVect());
-    if (save_interpolated) {
-        mf_interpolated = new amrex::MultiFab(mf_var->boxArray(), mf_var->DistributionMap(), 1, mf_var->nGrowVect());
-    }
+    mf_interp_lev0 = new amrex::MultiFab(mf_var->boxArray(), mf_var->DistributionMap(), 1, mf_var->nGrowVect());
 
     // dummy initialization
     i_time_before = -100;
@@ -93,7 +93,10 @@ void NCTimeSeries::Initialize() {
 /**
  * @param time   time to interpolate to
  */
-void NCTimeSeries::update_interpolated_to_time (amrex::Real time) {
+void NCTimeSeries::update_interpolated_to_time (amrex::Real time, int lev,
+                                                amrex::MultiFab* mf_lev,
+                                                const amrex::Vector<amrex::Geometry>& geom,
+                                                const amrex::Vector<amrex::IntVect>& ref_ratio) {
     // Figure out time index:
     AMREX_ASSERT(time >= ocean_times[0]);
     AMREX_ASSERT(time <= ocean_times[ocean_times.size()-1]);
@@ -119,20 +122,19 @@ void NCTimeSeries::update_interpolated_to_time (amrex::Real time) {
 
     amrex::Real dt = time_after - time_before;
 
-    auto nodality = mf_var->ixType();
+    auto nodality = mf_interp_lev0->ixType();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(*mf_var,true); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*mf_interp_lev0,true); mfi.isValid(); ++mfi) {
         // Adjust box to match ROMS grid
         amrex::Box bx = mfi.growntilebox(amrex::IntVect(1-nodality[0],1-nodality[1],0));
 
         amrex::Real time_before_copy = time_before;
 
-        // If we're saving the interpolated values, we fill mf_interpolated; otherwise, directly fill
-        // the multifab from the REMORA class
-        amrex::MultiFab* mf_to_fill = save_interpolated ? mf_interpolated : mf_var;
+        // Temporal interpolation is done once on level 0.
+        amrex::MultiFab* mf_to_fill = mf_interp_lev0;
         amrex::Array4<amrex::Real> to_fill = mf_to_fill->array(mfi);
         amrex::Array4<const amrex::Real> before = mf_before->const_array(mfi);
         amrex::Array4<const amrex::Real> after  = mf_after->const_array(mfi);
@@ -141,6 +143,69 @@ void NCTimeSeries::update_interpolated_to_time (amrex::Real time) {
             to_fill(i,j,k) = before(i,j,k) + (time - time_before_copy) * (after(i,j,k) - before(i,j,k)) / dt;
         });
     }
+
+    amrex::MultiFab* mf_to_fill_lev = mf_lev;
+    if (save_interpolated) {
+        if (mf_interpolated_lev.size() <= static_cast<std::size_t>(lev)) {
+            mf_interpolated_lev.resize(lev+1);
+        }
+        if (!mf_interpolated_lev[lev] ||
+            mf_interpolated_lev[lev]->boxArray() != mf_lev->boxArray() ||
+            mf_interpolated_lev[lev]->nGrowVect() != mf_lev->nGrowVect()) {
+            mf_interpolated_lev[lev] = std::make_unique<amrex::MultiFab>(
+                mf_lev->boxArray(), mf_lev->DistributionMap(), 1, mf_lev->nGrowVect());
+        }
+        mf_to_fill_lev = mf_interpolated_lev[lev].get();
+    }
+
+    if (lev == 0) {
+        amrex::MultiFab::Copy(*mf_to_fill_lev, *mf_interp_lev0, 0, 0, 1, mf_to_fill_lev->nGrowVect());
+        return;
+    }
+
+    amrex::PhysBCFunctNoOp null_bc_for_fill;
+    amrex::Vector<amrex::BCRec> null_dom_bcs(1);
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+        null_dom_bcs[0].setLo(dir, amrex::BCType::int_dir);
+        null_dom_bcs[0].setHi(dir, amrex::BCType::int_dir);
+    }
+
+    amrex::Interpolater* mapper = nullptr;
+    const auto& idx_type = mf_to_fill_lev->ixType();
+    if (idx_type == amrex::IndexType(amrex::IntVect(0,0,0))) {
+        mapper = &amrex::cell_cons_interp;
+    } else {
+        mapper = &amrex::face_cons_linear_interp;
+    }
+
+    amrex::InterpFromCoarseLevel(*mf_to_fill_lev, amrex::Real(0.0), *mf_interp_lev0,
+                                 0, 0, 1,
+                                 geom[0], geom[lev],
+                                 null_bc_for_fill, 0, null_bc_for_fill, 0,
+                                 cumulative_ref_ratio(lev, ref_ratio),
+                                 mapper, null_dom_bcs, 0);
+
+    mf_to_fill_lev->FillBoundary(geom[lev].periodicity());
+}
+
+amrex::IntVect
+NCTimeSeries::cumulative_ref_ratio (int lev,
+                                    const amrex::Vector<amrex::IntVect>& ref_ratio) const {
+    amrex::IntVect rr(1,1,1);
+    for (int l = 0; l < lev; ++l) {
+        rr[0] *= ref_ratio[l][0];
+        rr[1] *= ref_ratio[l][1];
+        rr[2] *= ref_ratio[l][2];
+    }
+    return rr;
+}
+
+const amrex::MultiFab*
+NCTimeSeries::get_interpolated_mf (int lev) const {
+    AMREX_ALWAYS_ASSERT(save_interpolated);
+    AMREX_ALWAYS_ASSERT(lev < static_cast<int>(mf_interpolated_lev.size()));
+    AMREX_ALWAYS_ASSERT(mf_interpolated_lev[lev]);
+    return mf_interpolated_lev[lev].get();
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -702,8 +702,8 @@ REMORA::set_smflux(int lev)
         prob->init_analytic_smflux(lev, geom[lev], solverChoice, *this,*vec_sustr[lev], *vec_svstr[lev]);
     } else if (solverChoice.smflux_type == SMFluxType::netcdf) {
 #ifdef REMORA_USE_NETCDF
-        sustr_data_from_file->update_interpolated_to_time(t_old[lev]);
-        svstr_data_from_file->update_interpolated_to_time(t_old[lev]);
+        sustr_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_sustr[lev].get(), geom, ref_ratio);
+        svstr_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_svstr[lev].get(), geom, ref_ratio);
         FillPatch(lev, t_old[lev], *vec_sustr[lev], GetVecOfPtrs(vec_sustr),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         FillPatch(lev, t_old[lev], *vec_svstr[lev], GetVecOfPtrs(vec_svstr),BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
 #endif
@@ -721,8 +721,8 @@ REMORA::set_wind(int lev)
         prob->init_analytic_wind(lev,geom[lev], solverChoice, *this, *vec_uwind[lev], *vec_vwind[lev]);
     } else if (solverChoice.wind_type == WindType::netcdf) {
 #ifdef REMORA_USE_NETCDF
-        Uwind_data_from_file->update_interpolated_to_time(t_old[lev]);
-        Vwind_data_from_file->update_interpolated_to_time(t_old[lev]);
+        Uwind_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_uwind[lev].get(), geom, ref_ratio);
+        Vwind_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_vwind[lev].get(), geom, ref_ratio);
         FillPatch(lev, t_old[lev], *vec_uwind[lev], GetVecOfPtrs(vec_uwind),
                   BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         FillPatch(lev, t_old[lev], *vec_vwind[lev], GetVecOfPtrs(vec_vwind),
@@ -730,12 +730,12 @@ REMORA::set_wind(int lev)
 
         // Conditionally update atmospheric fields if loaded from NetCDF
         if (solverChoice.Tair_from_netcdf) {
-            Tair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            Tair_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_Tair[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_Tair[lev], GetVecOfPtrs(vec_Tair),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.qair_from_netcdf) {
-            qair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            qair_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_qair[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_qair[lev], GetVecOfPtrs(vec_qair),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
 
@@ -748,32 +748,32 @@ REMORA::set_wind(int lev)
             }
         }
         if (solverChoice.Pair_from_netcdf) {
-            Pair_data_from_file->update_interpolated_to_time(t_old[lev]);
+            Pair_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_Pair[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_Pair[lev], GetVecOfPtrs(vec_Pair),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.srflx_from_netcdf) {
-            srflx_data_from_file->update_interpolated_to_time(t_old[lev]);
+            srflx_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_srflx[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_srflx[lev], GetVecOfPtrs(vec_srflx),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.longwave_down_from_netcdf) {
-            longwave_down_data_from_file->update_interpolated_to_time(t_old[lev]);
+            longwave_down_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_longwave_down[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_longwave_down[lev], GetVecOfPtrs(vec_longwave_down),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.rain_from_netcdf) {
-            rain_data_from_file->update_interpolated_to_time(t_old[lev]);
+            rain_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_rain[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_rain[lev], GetVecOfPtrs(vec_rain),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.cloud_from_netcdf) {
-            cloud_data_from_file->update_interpolated_to_time(t_old[lev]);
+            cloud_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_cloud[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_cloud[lev], GetVecOfPtrs(vec_cloud),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
         if (solverChoice.EminusP_from_netcdf) {
-            EminusP_data_from_file->update_interpolated_to_time(t_old[lev]);
+            EminusP_data_from_file->update_interpolated_to_time(t_old[lev], lev, vec_EminusP[lev].get(), geom, ref_ratio);
             FillPatch(lev, t_old[lev], *vec_EminusP[lev], GetVecOfPtrs(vec_EminusP),
                       BCVars::foextrap_periodic_bc,BdyVars::null,0,false);
         }
@@ -841,7 +841,7 @@ REMORA::init_only (int lev, Real time)
     if (solverChoice.ic_type == IC_Type::netcdf) {
         init_clim_nudg_coeff(lev);
 
-        if (solverChoice.do_any_clim_nudg) {
+        if (solverChoice.do_any_clim_nudg && lev == 0) {
             if (nc_clim_his_file.empty()) {
                 amrex::Error("NetCDF climatology file name must be provided via input");
             }
@@ -877,7 +877,7 @@ REMORA::init_only (int lev, Real time)
     }
 
     // This will be a non-op if forcings specified analytically
-    if (solverChoice.wind_type == WindType::netcdf) {
+    if (solverChoice.wind_type == WindType::netcdf && lev == 0) {
         if (nc_frc_file.empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for winds");
         }
@@ -915,7 +915,7 @@ REMORA::init_only (int lev, Real time)
             EminusP_data_from_file = new NCTimeSeries(nc_frc_file, "EminusP", frc_time_varname, geom[lev].Domain(),vec_EminusP[lev].get(), true, false);
             EminusP_data_from_file->Initialize();
         }
-    } else if (solverChoice.smflux_type == SMFluxType::netcdf) {
+    } else if (solverChoice.smflux_type == SMFluxType::netcdf && lev == 0) {
         if (nc_frc_file.empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for surface momentum fluxes");
         }
@@ -924,7 +924,7 @@ REMORA::init_only (int lev, Real time)
         sustr_data_from_file->Initialize();
         svstr_data_from_file->Initialize();
     }
-    if (solverChoice.longwave_down_from_netcdf) {
+    if (solverChoice.longwave_down_from_netcdf && lev == 0) {
         if (nc_frc_file.empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for longwave radiation");
         }

--- a/Source/TimeIntegration/REMORA_advance_2d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_2d.cpp
@@ -193,8 +193,8 @@ REMORA::advance_2d (int lev,
 
 #ifdef REMORA_USE_NETCDF
     if (solverChoice.do_m2_clim_nudg) {
-        ubar_clim_data_from_file->update_interpolated_to_time(t_new[lev]);
-        vbar_clim_data_from_file->update_interpolated_to_time(t_new[lev]);
+        ubar_clim_data_from_file->update_interpolated_to_time(t_new[lev], lev, vec_ubar[lev].get(), geom, ref_ratio);
+        vbar_clim_data_from_file->update_interpolated_to_time(t_new[lev], lev, vec_vbar[lev].get(), geom, ref_ratio);
     }
 #endif
 
@@ -574,8 +574,8 @@ REMORA::advance_2d (int lev,
         if (solverChoice.do_m2_clim_nudg) {
             Array4<Real      > const& ubar_krhs    = mf_ubar->array(mfi, krhs);
             Array4<Real      > const& vbar_krhs    = mf_vbar->array(mfi, krhs);
-            Array4<const Real> const& ubar_clim = ubar_clim_data_from_file->mf_interpolated->const_array(mfi);
-            Array4<const Real> const& vbar_clim = vbar_clim_data_from_file->mf_interpolated->const_array(mfi);
+            Array4<const Real> const& ubar_clim = ubar_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
+            Array4<const Real> const& vbar_clim = vbar_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<const Real> const& ubar_nudg_coeff = vec_nudg_coeff[BdyVars::ubar][lev]->const_array(mfi);
             Array4<const Real> const& vbar_nudg_coeff = vec_nudg_coeff[BdyVars::vbar][lev]->const_array(mfi);
             // Boxes are like this to match ROMS

--- a/Source/TimeIntegration/REMORA_advance_3d.cpp
+++ b/Source/TimeIntegration/REMORA_advance_3d.cpp
@@ -454,13 +454,13 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
 
 #ifdef REMORA_USE_NETCDF
     if (solverChoice.do_temp_clim_nudg) {
-        temp_clim_data_from_file->update_interpolated_to_time(t_old[lev]);
+        temp_clim_data_from_file->update_interpolated_to_time(t_old[lev], lev, cons_new[lev], geom, ref_ratio);
 
         for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
             Box bx = mfi.growntilebox(IntVect(1,1,0));
             Array4<const Real> const& temp_nudg_coeff = vec_nudg_coeff[BdyVars::t][lev]->const_array(mfi);
-            Array4<const Real> const& temp_clim = temp_clim_data_from_file->mf_interpolated->const_array(mfi);
+            Array4<const Real> const& temp_clim = temp_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<      Real> const& temp = cons_new[lev]->array(mfi, Temp_comp);
             Array4<const Real> const& Hz   = vec_Hz[lev]->const_array(mfi);
             Array4<const Real> const& pm   = vec_pm[lev]->const_array(mfi);
@@ -470,13 +470,13 @@ REMORA::advance_3d (int lev, MultiFab& mf_cons,
         }
     }
     if (solverChoice.do_salt_clim_nudg) {
-        salt_clim_data_from_file->update_interpolated_to_time(t_old[lev]);
+        salt_clim_data_from_file->update_interpolated_to_time(t_old[lev], lev, cons_new[lev], geom, ref_ratio);
 
         for ( MFIter mfi(mf_cons, TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
             Box bx = mfi.growntilebox(IntVect(1,1,0));
             Array4<const Real> const& salt_nudg_coeff = vec_nudg_coeff[BdyVars::s][lev]->const_array(mfi);
-            Array4<const Real> const& salt_clim = salt_clim_data_from_file->mf_interpolated->const_array(mfi);
+            Array4<const Real> const& salt_clim = salt_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<      Real> const& salt = cons_new[lev]->array(mfi, Salt_comp);
             Array4<const Real> const& Hz   = vec_Hz[lev]->const_array(mfi);
             Array4<const Real> const& pm   = vec_pm[lev]->const_array(mfi);

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -329,8 +329,8 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 #ifdef REMORA_USE_NETCDF
     // Get u and v climatology if we're going to do nudging
     if (solverChoice.do_m3_clim_nudg) {
-        u_clim_data_from_file->update_interpolated_to_time(t_new[lev]);
-        v_clim_data_from_file->update_interpolated_to_time(t_new[lev]);
+        u_clim_data_from_file->update_interpolated_to_time(t_new[lev], lev, xvel_new[lev], geom, ref_ratio);
+        v_clim_data_from_file->update_interpolated_to_time(t_new[lev], lev, yvel_new[lev], geom, ref_ratio);
     }
 #endif
 
@@ -456,8 +456,8 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
 #ifdef REMORA_USE_NETCDF
         if (solverChoice.do_m3_clim_nudg) {
-            Array4<const Real> const& uclim = u_clim_data_from_file->mf_interpolated->const_array(mfi);
-            Array4<const Real> const& vclim = v_clim_data_from_file->mf_interpolated->const_array(mfi);
+            Array4<const Real> const& uclim = u_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
+            Array4<const Real> const& vclim = v_clim_data_from_file->get_interpolated_mf(lev)->const_array(mfi);
             Array4<const Real> const& u_nudg_coeff = vec_nudg_coeff[BdyVars::u][lev]->const_array(mfi);
             Array4<const Real> const& v_nudg_coeff = vec_nudg_coeff[BdyVars::v][lev]->const_array(mfi);
             // These boxes are set to match ROMS


### PR DESCRIPTION
I've modified the 'update_interpolated_to_time' function to allow for interpolation of level0 netcdf data to the finer mesh. The flow in the updated function is:
- Read level-0 netcdf data
- Do temporal interpolation once into level-0 interpolated cache.
- If level0 only, copy the level0 data.
- If lev > 0: call InterpFromCoarseLevel with cumulative refinement ratio
