### PR TITLE
added functionality for providing net lward, rather than just downward

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -965,6 +965,21 @@ List of Bulk Fluxes parameters
 |                                  |                                        |                   |                |
 |                                  | (spatially varying)                    |                   |                |
 +----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.longwave_down**         | Use file-provided downward longwave    | true / false      | false          |
+|                                  | radiation to compute net longwave      |                   |                |
+|                                  | (``Lnet = Ldown - sigma*epsilon*T^4``) |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.longwave_down_from_netcdf** | Load longwave field from NetCDF    | true / false      | false          |
+|                                  | file (spatially varying)               |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.longwave_netcdf_is_net**| Interpret the NetCDF longwave field    | true / false      | false          |
+|                                  | as net longwave (use as-is). If false, |                   |                |
+|                                  | interpret as downward longwave and     |                   |                |
+|                                  | compute net in the bulk flux routine   |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.longwave_netcdf_varname** | Name of the NetCDF longwave variable | String            | ``lwrad``      |
+|                                  | in ``remora.nc_frc_file``              |                   |                |
++----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.blk_ZQ**                | Height [m] of atmospheric              | Real number       | 10.0           |
 |                                  |                                        |                   |                |
 |                                  | humidity memasurements for             |                   |                |
@@ -1026,13 +1041,21 @@ List of Bulk Fluxes parameters
 
    When loading atmospheric forcing variables from NetCDF files (by setting
    **Tair_from_netcdf**, **qair_from_netcdf**, **Pair_from_netcdf**,
-   **srflx_from_netcdf**, **rain_from_netcdf**, **cloud_from_netcdf**, or
-   **EminusP_from_netcdf** to true), these variables are read from the file
+   **srflx_from_netcdf**, **longwave_down_from_netcdf**,
+   **rain_from_netcdf**, **cloud_from_netcdf**, or **EminusP_from_netcdf**
+   to true), these variables are read from the file
    specified by **remora.nc_frc_file** (see :ref:`list-of-parameters surface-forcing`).
    The NetCDF file must contain variables named ``Tair``, ``qair``, ``Pair``,
    ``swrad``, ``rain``, ``cloud``, and ``EminusP`` respectively, with the same
    spatial dimensions as the model grid.
    Time interpolation is performed automatically based on the simulation time.
+
+   For longwave forcing, the variable name is controlled by
+   **remora.longwave_netcdf_varname** (default ``lwrad``).
+   If **remora.longwave_netcdf_is_net** is true, that variable is treated as
+   net longwave radiation and used directly. If false, it is treated as
+   downward longwave radiation and net longwave is computed in the bulk-flux
+   routine using sea-surface temperature and emissivity.
 
    The **qair_is_percent** flag should be set to true if the relative humidity
    in the NetCDF file is stored as a percentage (0-100) rather than as a

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -909,7 +909,8 @@ REMORA::init_only (int lev, Real time)
         if (nc_frc_file.empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for longwave radiation");
         }
-        longwave_down_data_from_file = new NCTimeSeries(nc_frc_file, "longwave_down", frc_time_varname, geom[lev].Domain(), vec_longwave_down[lev].get(), true, false);
+            longwave_down_data_from_file = new NCTimeSeries(nc_frc_file, solverChoice.longwave_netcdf_varname, frc_time_varname,
+                                                            geom[lev].Domain(), vec_longwave_down[lev].get(), true, false);
         longwave_down_data_from_file->Initialize();
     }
 

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -193,6 +193,8 @@ struct SolverChoice {
         pp.queryAdd("srflx_from_netcdf",srflx_from_netcdf);
         pp.queryAdd("longwave_down", longwave_down);
         pp.queryAdd("longwave_down_from_netcdf",longwave_down_from_netcdf);
+        pp.queryAdd("longwave_netcdf_is_net", longwave_netcdf_is_net);
+        pp.queryAdd("longwave_netcdf_varname", longwave_netcdf_varname);
         pp.queryAdd("cloud",cloud);
         pp.queryAdd("rain",rain);
         pp.queryAdd("blk_ZQ",blk_ZQ);
@@ -208,6 +210,16 @@ struct SolverChoice {
         pp.queryAdd("rain_from_netcdf",rain_from_netcdf);
         pp.queryAdd("cloud_from_netcdf",cloud_from_netcdf);
         pp.queryAdd("EminusP_from_netcdf",EminusP_from_netcdf);
+
+        if (longwave_netcdf_is_net) {
+            // If user provides net longwave from NetCDF, force use of file-based longwave.
+            longwave_down = true;
+            longwave_down_from_netcdf = true;
+        }
+
+        if (!longwave_down_from_netcdf && longwave_netcdf_varname != "lwrad") {
+            amrex::Warning("remora.longwave_netcdf_varname is set but remora.longwave_down_from_netcdf is false; the value will be ignored.");
+        }
 
         if (eminusp_correct_ssh and !eminusp) {
             amrex::Abort("If evaporation minus precipitation (E-P) sea surface height correct in is on, E-P must be on as well (remora.eminusp=true)");
@@ -575,10 +587,12 @@ struct SolverChoice {
     bool        Pair_from_netcdf      = false;
     bool        srflx_from_netcdf     = false;
     bool        longwave_down_from_netcdf          = false;
+    bool        longwave_netcdf_is_net = false;
     bool        rain_from_netcdf      = false;
     bool        cloud_from_netcdf     = false;
     bool        EminusP_from_netcdf   = false;
     bool        qair_is_percent       = false;
+    std::string longwave_netcdf_varname = "lwrad";
 
 
     bool        do_rivers             = false;

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -74,6 +74,8 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Real blk_ZW = solverChoice.blk_ZW;
 
         bool use_longwave_down = solverChoice.longwave_down;
+        bool longwave_netcdf_is_net = solverChoice.longwave_netcdf_is_net;
+        bool have_longwave_from_file = (mf_longwave_down != nullptr);
 
         Real eps = 1e-20_rt;
 
@@ -120,7 +122,10 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
                1.0 at poles to 0.5 at the Equator).
 
             */
-            if (use_longwave_down) {
+            if (have_longwave_from_file && longwave_netcdf_is_net) {
+                // File provides net longwave directly (W/m2), no additional conversion.
+                LRad = longwave_down_arr(i,j,0);
+            } else if (use_longwave_down) {
                 Real Ldown = longwave_down_arr(i,j,0);
                 Real Lemit = emmiss * StefBo * std::pow(TseaK,4);
                 LRad = Ldown - Lemit;

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -180,6 +180,14 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
     const Real Cdb_min = solverChoice.Cdb_min;
     const Real Cdb_max = solverChoice.Cdb_max;
 
+    if (solverChoice.longwave_netcdf_is_net && !solverChoice.longwave_down_from_netcdf) {
+        amrex::Abort("remora.longwave_netcdf_is_net=true requires remora.longwave_down_from_netcdf=true");
+    }
+
+    if (solverChoice.longwave_down && !solverChoice.longwave_down_from_netcdf) {
+        amrex::Abort("remora.longwave_down=true currently requires remora.longwave_down_from_netcdf=true");
+    }
+
     MultiFab* lw_ptr = nullptr;
 
     if (solverChoice.longwave_down_from_netcdf)


### PR DESCRIPTION
Past PR added in spatially varying downward longwave radiation but assumed only downward and computed net. This PR adds functionality to provide either downward or net longwave and specification in the input file will determine whether net needs to be computed or not. I've added documentation to reflect how to use these options in the inputs file. 