### PR TITLE
Adds laplacian mixing coefficients scaled to the grid size and refinement level

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -802,8 +802,7 @@ Scaled-to-grid horizontal mixing
 --------------------------------
 
 If ``remora.horizontal_mixing_type = "scaled_to_grid"``, REMORA follows the ROMS-style approach of
-scaling horizontal harmonic mixing coefficients by a grid-size metric derived from the curvilinear
-metrics ``pm`` and ``pn`` (read from the NetCDF grid file):
+scaling horizontal harmonic mixing coefficients by the grid cell area. 
 
 .. math::
 
@@ -816,7 +815,10 @@ metrics ``pm`` and ``pn`` (read from the NetCDF grid file):
 
 where :math:`\\nu_0` is ``remora.visc2`` and :math:`\\kappa_{0,n}` are the tracer diffusivities
 (``remora.tnu2_temp``, ``remora.tnu2_salt``, ``remora.tnu2_scalar``). This ensures the *maximum*
-coefficient equals the user-specified value, while varying spatially with grid size.
+coefficient over the normalization region equals the user-specified value, while varying spatially
+with grid size. Note that if the largest cell area occurs over land, then the maximum over *wet*
+cells (and thus what you see after applying ``mask_rho`` in post-processing) may be smaller than
+the user-specified value.
 
 Implementation details
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -727,8 +727,8 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``scaled_to_grid`` scales harmonic     |                   |                |
 |                                   | viscosity/diffusivity by the grid      |                   |                |
-|                                   | cell area. Equivalent to ``DIFF_GRID`` |                   |                | 
-|                                   | and ``VISC_GRID`` in ROMS.             |                   |                | 
+|                                   | cell area. Equivalent to ``DIFF_GRID`` |                   |                |
+|                                   | and ``VISC_GRID`` in ROMS.             |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.visc2**                  | Constant horizontal viscosity,         | Real number       | 0.0            |
 |                                   |                                        |                   |                |
@@ -802,7 +802,7 @@ Scaled-to-grid horizontal mixing
 --------------------------------
 
 If ``remora.horizontal_mixing_type = "scaled_to_grid"``, REMORA follows the ROMS-style approach of
-scaling horizontal harmonic mixing coefficients by the grid cell area. 
+scaling horizontal harmonic mixing coefficients by the grid cell area.
 
 .. math::
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -730,6 +730,13 @@ List of Parameters
 |                                   | cell area. Equivalent to ``DIFF_GRID`` |                   |                |
 |                                   | and ``VISC_GRID`` in ROMS.             |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
+| **remora.scaled_to_grid_amr_scaling** | AMR scaling behavior for                | ``none`` /        | ``none``       |
+|                                   | ``scaled_to_grid`` and ``constant``     | ``linear``        |                |
+|                                   | coefficients on refined levels.         |                   |                |
+|                                   | ``linear`` decreases coefficients in    |                   |                |
+|                                   | proportion to the horizontal refinement |                   |                |
+|                                   | ratio.                                  |                   |                |
++-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.visc2**                  | Constant horizontal viscosity,         | Real number       | 0.0            |
 |                                   |                                        |                   |                |
 |                                   | everywhere. Needed when                |                   |                |
@@ -826,6 +833,11 @@ Implementation details
 - The normalization ``max(G)`` is computed as a global maximum over the level-0 grid (rho points at
   the surface, i.e. ``k=0``) and does not use land/sea masks. Equivalently, it uses the maximum grid-cell
   area :math:`A(i,j) = 1/(pm\,pn)` via :math:`\\max(G)=\\sqrt{\\max(A)}`.
+
+- AMR refinement scaling: if ``remora.scaled_to_grid_amr_scaling = "linear"``, then on AMR level
+  :math:`\\ell` the coefficients are additionally scaled by the cumulative horizontal refinement ratio,
+  :math:`1/\\prod_{m<\\ell}\\sqrt{r_x(m)\,r_y(m)}`. For example, with a refinement ratio of ``5 5 1``,
+  level 1 coefficients are reduced by a factor of 5 relative to level 0.
 
 - Ghost cells for the coefficient fields are filled using the same periodic/foextrap boundary fill
   used elsewhere in REMORA. This is done so stencil-based operations (e.g., the psi-point averaging for

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -723,7 +723,12 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``analytic`` means function is         | ``constant``      |                |
 |                                   |                                        |                   |                |
-|                                   | specified in ``prob.cpp``.             |                   |                |
+|                                   | specified in ``prob.cpp``.             | / ``scaled_to_grid`` |             |
+|                                   |                                        |                   |                |
+|                                   | ``scaled_to_grid`` scales harmonic     |                   |                |
+|                                   | viscosity/diffusivity by the grid      |                   |                |
+|                                   | cell area. Equivalent to ``DIFF_GRID`` |                   |                | 
+|                                   | and ``VISC_GRID`` in ROMS.             |                   |                | 
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.visc2**                  | Constant horizontal viscosity,         | Real number       | 0.0            |
 |                                   |                                        |                   |                |
@@ -731,7 +736,9 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``horizontal_mixing_type`` is          |                   |                |
 |                                   |                                        |                   |                |
-|                                   | ``constant``.                          |                   |                |
+|                                   | ``constant`` or ``scaled_to_grid``     |                   |                |
+|                                   | (in this case, it is the maximum       |                   |                |
+|                                   | viscosity over the domain).            |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.tnu2_salt**              | Constant horizontal diffusivity,       | Real number       | 0.0            |
 |                                   |                                        |                   |                |
@@ -741,7 +748,9 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``horizontal_mixing_type`` is          |                   |                |
 |                                   |                                        |                   |                |
-|                                   | ``constant``.                          |                   |                |
+|                                   | ``constant`` or ``scaled_to_grid``     |                   |                |
+|                                   | (in this case, it is the maximum       |                   |                |
+|                                   | salt diffusivity over the domain).     |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.tnu2_temp**              | Constant horizontal diffusivity,       | Real number       | 0.0            |
 |                                   |                                        |                   |                |
@@ -751,7 +760,10 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``horizontal_mixing_type``             |                   |                |
 |                                   |                                        |                   |                |
-|                                   | is ``constant``.                       |                   |                |
+|                                   | is ``constant`` or ``scaled_to_grid``  |                   |                |
+|                                   | (in this case, it is the maximum       |                   |                |
+|                                   | temperature diffusivity over the       |                   |                |
+|                                   | domain).                               |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.tnu2_scalar**            | Constant horizontal diffusivity,       | Real number       | 0.0            |
 |                                   |                                        |                   |                |
@@ -761,7 +773,9 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | ``horizontal_mixing_type``             |                   |                |
 |                                   |                                        |                   |                |
-|                                   | is ``constant``.                       |                   |                |
+|                                   | is ``constant`` or ``scaled_to_grid``  |                   |                |
+|                                   | (in this case, it is the maximum       |                   |                |
+|                                   | scalar diffusivity over the domain).   |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.vertical_mixing_type**   | Vertical mixing type. ``analytic``     | ``analytic`` /    | ``analytic``   |
 |                                   |                                        |                   |                |
@@ -783,6 +797,44 @@ List of Parameters
 |                                   |                                        |                   |                |
 |                                   | parametrization                        |                   |                |
 +-----------------------------------+----------------------------------------+-------------------+----------------+
+
+Scaled-to-grid horizontal mixing
+--------------------------------
+
+If ``remora.horizontal_mixing_type = "scaled_to_grid"``, REMORA follows the ROMS-style approach of
+scaling horizontal harmonic mixing coefficients by a grid-size metric derived from the curvilinear
+metrics ``pm`` and ``pn`` (read from the NetCDF grid file):
+
+.. math::
+
+   G(i,j) = \sqrt{\frac{1}{pm(i,j)\,pn(i,j)}}
+
+.. math::
+
+   \nu(i,j) = \nu_0 \frac{G(i,j)}{\max(G)}, \qquad
+   \kappa_n(i,j) = \kappa_{0,n} \frac{G(i,j)}{\max(G)}
+
+where :math:`\\nu_0` is ``remora.visc2`` and :math:`\\kappa_{0,n}` are the tracer diffusivities
+(``remora.tnu2_temp``, ``remora.tnu2_salt``, ``remora.tnu2_scalar``). This ensures the *maximum*
+coefficient equals the user-specified value, while varying spatially with grid size.
+
+Implementation details
+^^^^^^^^^^^^^^^^^^^^^^
+
+- The normalization ``max(G)`` is computed as a global maximum over the level-0 grid (rho points at
+  the surface, i.e. ``k=0``) and does not use land/sea masks. Equivalently, it uses the maximum grid-cell
+  area :math:`A(i,j) = 1/(pm\,pn)` via :math:`\\max(G)=\\sqrt{\\max(A)}`.
+
+- Ghost cells for the coefficient fields are filled using the same periodic/foextrap boundary fill
+  used elsewhere in REMORA. This is done so stencil-based operations (e.g., the psi-point averaging for
+  ``visc2_p``) have valid neighbor values near domain boundaries and coarse/fine interfaces. Output
+  (plotfiles / NetCDF) writes only the valid region.
+
+When this option is active, the spatially varying coefficients are automatically included in plot output
+as 2D (vertically homogeneous) fields:
+
+- ``visc2`` (horizontal viscosity at rho points)
+- ``diff2_temp``, ``diff2_salt``, ``diff2_tracer`` (horizontal diffusivities at rho points)
 
 .. _list-of-parameters-drag:
 

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -131,8 +131,13 @@ Notes
    ``diff2_salt``, and ``diff2_tracer``.
 
    - For NetCDF output they are written as time-invariant variables (no ``ocean_time`` dimension).
-   - For native AMReX plotfiles they are written once into a static plotfile named
-     ``<remora.plot_file>_hmixcoef`` (and omitted from the regular time-series plotfiles).
+   - For native AMReX plotfiles they are written into a companion coefficient plotfile named
+     ``<plotfilename>_hmixcoef`` (e.g., ``plt00010_hmixcoef``), and omitted from the regular
+     time-series plotfiles. This is written per plot output so it matches the current AMR grid
+     hierarchy.
+   - For AMReX output these coefficient fields are written as a k=0 slab (nz=1). Some analysis tools
+     may therefore show a singleton vertical dimension; this can be removed in post-processing with
+     ``squeeze()`` or by selecting the first plane.
    - The coefficients are written for the valid region only (ghost cells are not written).
 
 -  File prefixes can include directories.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -148,9 +148,7 @@ Notes
      ``<plotfilename>_hmixcoef`` (e.g., ``plt00010_hmixcoef``), and omitted from the regular
      time-series plotfiles. This is written per plot output so it matches the current AMR grid
      hierarchy.
-   - For AMReX output these coefficient fields are written as a k=0 slab (nz=1). Some analysis tools
-     may therefore show a singleton vertical dimension; this can be removed in post-processing with
-     ``squeeze()`` or by selecting the first plane.
+   - For AMReX output these coefficient fields are written as a k=0 slab. 
    - The coefficients are written for the valid region only (ghost cells are not written).
 
 -  File prefixes can include directories.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -148,7 +148,7 @@ Notes
      ``<plotfilename>_hmixcoef`` (e.g., ``plt00010_hmixcoef``), and omitted from the regular
      time-series plotfiles. This is written per plot output so it matches the current AMR grid
      hierarchy.
-   - For AMReX output these coefficient fields are written as a k=0 slab. 
+   - For AMReX output these coefficient fields are written as a k=0 slab.
    - The coefficients are written for the valid region only (ghost cells are not written).
 
 -  File prefixes can include directories.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -139,18 +139,6 @@ Notes
    cell centers when written in amrex/native plotfiles. They are not averaged when writing
    NetCDF files.
 
--  If ``remora.horizontal_mixing_type = "scaled_to_grid"``, REMORA outputs the spatially varying
-   horizontal mixing coefficients as 2D (vertically homogeneous) fields: ``visc2``, ``diff2_temp``,
-   ``diff2_salt``, and ``diff2_tracer``.
-
-   - For NetCDF output they are written as time-invariant variables (no ``ocean_time`` dimension).
-   - For native AMReX plotfiles they are written into a companion coefficient plotfile named
-     ``<plotfilename>_hmixcoef`` (e.g., ``plt00010_hmixcoef``), and omitted from the regular
-     time-series plotfiles. This is written per plot output so it matches the current AMR grid
-     hierarchy.
-   - For AMReX output these coefficient fields are written as a k=0 slab.
-   - The coefficients are written for the valid region only (ghost cells are not written).
-
 -  File prefixes can include directories.
 
 -  If both ``remora.plot_int`` and ``remora.plot_int_time`` have been set, plotfile output will occur

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -81,8 +81,9 @@ List of Parameters
 |                                        | 3D variables to                   |                       |            |
 |                                        | include in                        | (see table below)     |            |
 |                                        |                                   |                       |            |
-|                                        | plotfiles. Not                    |                       |            |
-|                                        | used for netCDF                   |                       |            |
+|                                        | plotfiles. Also used to select    |                       |            |
+|                                        | optional 3D tracer/derived fields |                       |            |
+|                                        | in NetCDF plotfiles.              |                       |            |
 +----------------------------------------+-----------------------------------+-----------------------+------------+
 | **remora.plot_vars_2d**                | name of                           | list of names         | None       |
 |                                        | 2D variables to                   |                       |            |
@@ -125,6 +126,15 @@ Notes
    cell centers when written in amrex/native plotfiles. They are not averaged when writing
    NetCDF files.
 
+-  If ``remora.horizontal_mixing_type = "scaled_to_grid"``, REMORA outputs the spatially varying
+   horizontal mixing coefficients as 2D (vertically homogeneous) fields: ``visc2``, ``diff2_temp``,
+   ``diff2_salt``, and ``diff2_tracer``.
+
+   - For NetCDF output they are written as time-invariant variables (no ``ocean_time`` dimension).
+   - For native AMReX plotfiles they are written once into a static plotfile named
+     ``<remora.plot_file>_hmixcoef`` (and omitted from the regular time-series plotfiles).
+   - The coefficients are written for the valid region only (ghost cells are not written).
+
 -  File prefixes can include directories.
 
 -  If both ``remora.plot_int`` and ``remora.plot_int_time`` have been set, plotfile output will occur
@@ -162,6 +172,17 @@ Notes
 | **zeta**                       |                           |
 +--------------------------------+---------------------------+
 | **h**                          |                           |
++--------------------------------+---------------------------+
+| **visc2**                      | horizontal viscosity      |
++--------------------------------+---------------------------+
+| **diff2_temp**                 | horizontal diffusivity    |
+|                                | for temperature           |
++--------------------------------+---------------------------+
+| **diff2_salt**                 | horizontal diffusivity    |
+|                                | for salinity              |
++--------------------------------+---------------------------+
+| **diff2_tracer**               | horizontal diffusivity    |
+|                                | for passive tracer        |
 +--------------------------------+---------------------------+
 | **ubar**                       |                           |
 +--------------------------------+---------------------------+

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -1133,7 +1133,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             // vertically homogeneous and time-invariant -> write static 2D fields once.
             // **************************************************************************
             if ((solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) && write_header) {
-                { // visc2 (k=0 plane)
+                { // visc2
                     FArrayBox tmp;
                     tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
                     tmp.template copy<RunOn::Device>((*vec_visc2_r[lev])[mfi.index()], 0, 0, 1);
@@ -1143,7 +1143,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
                     nc_var.put(tmp.dataPtr(), { local_start_y, local_start_x }, { local_ny, local_nx });
                 }
 
-                // diff2_* (k=0 plane)
+                // diff2_*
                 for (int n = 0; n < NCONS; ++n) {
                     const std::string nm = std::string("diff2_") + cons_names[n];
                     FArrayBox tmp;

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -414,60 +414,28 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             }
         } // end vorticity
 
-        {
-            int comp = -1;
-            for (int i = 0; i < plot_var_names_3d.size(); i++) {
-                if (plot_var_names_3d[i] == "visc2") comp = i;
-            }
-            if (comp >= 0) {
-                // For scaled_to_grid, viscosity is time-invariant; write it as a static variable
-                // without an ocean_time dimension (and only write it once per file).
-                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-                    ncf.def_var_fill("visc2", ncutils::NCDType::Real, { nz_r_name, ny_r_name, nx_r_name }, &fill_value);
-                } else {
-                    ncf.def_var_fill("visc2", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_r_name, nx_r_name }, &fill_value);
-                }
-                ncf.var("visc2").put_attr("long_name","horizontal harmonic viscosity coefficient at RHO-points");
-                ncf.var("visc2").put_attr("units","meter2 second-1");
-                ncf.var("visc2").put_attr("grid","grid");
-                ncf.var("visc2").put_attr("location","face");
-                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-                    ncf.var("visc2").put_attr("coordinates","x_rho y_rho s_rho");
-                    ncf.var("visc2").put_attr("field","visc2, scalar");
-                } else {
-                    ncf.var("visc2").put_attr("time","ocean_time");
-                    ncf.var("visc2").put_attr("coordinates","x_rho y_rho s_rho ocean_time");
-                    ncf.var("visc2").put_attr("field","visc2, scalar, series");
-                }
-            }
-        } // end visc2
+        // Horizontal mixing coefficients are vertically homogeneous. For scaled_to_grid we output
+        // them as static 2D rho-point fields (no ocean_time, no s_rho).
+        if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+            ncf.def_var_fill("visc2", ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &fill_value);
+            ncf.var("visc2").put_attr("long_name","horizontal harmonic viscosity coefficient at RHO-points");
+            ncf.var("visc2").put_attr("units","meter2 second-1");
+            ncf.var("visc2").put_attr("grid","grid");
+            ncf.var("visc2").put_attr("location","face");
+            ncf.var("visc2").put_attr("coordinates","x_rho y_rho");
+            ncf.var("visc2").put_attr("field","visc2, scalar");
 
-        for (int n = 0; n < NCONS; ++n) {
-            const std::string nm = std::string("diff2_") + cons_names[n];
-            int comp = -1;
-            for (int i = 0; i < plot_var_names_3d.size(); i++) {
-                if (plot_var_names_3d[i] == nm) comp = i;
-            }
-            if (comp >= 0) {
-                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-                    ncf.def_var_fill(nm, ncutils::NCDType::Real, { nz_r_name, ny_r_name, nx_r_name }, &fill_value);
-                } else {
-                    ncf.def_var_fill(nm, ncutils::NCDType::Real, { nt_name, nz_r_name, ny_r_name, nx_r_name }, &fill_value);
-                }
+            for (int n = 0; n < NCONS; ++n) {
+                const std::string nm = std::string("diff2_") + cons_names[n];
+                ncf.def_var_fill(nm, ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &fill_value);
                 ncf.var(nm).put_attr("long_name", std::string("horizontal harmonic diffusivity coefficient for ") + cons_names[n] + " at RHO-points");
                 ncf.var(nm).put_attr("units","meter2 second-1");
                 ncf.var(nm).put_attr("grid","grid");
                 ncf.var(nm).put_attr("location","face");
-                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-                    ncf.var(nm).put_attr("coordinates","x_rho y_rho s_rho");
-                    ncf.var(nm).put_attr("field", nm + ", scalar");
-                } else {
-                    ncf.var(nm).put_attr("time","ocean_time");
-                    ncf.var(nm).put_attr("coordinates","x_rho y_rho s_rho ocean_time");
-                    ncf.var(nm).put_attr("field", nm + ", scalar, series");
-                }
+                ncf.var(nm).put_attr("coordinates","x_rho y_rho");
+                ncf.var(nm).put_attr("field", nm + ", scalar");
             }
-        } // end diff2_*
+        }
 
         ncf.def_var_fill("u", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_u_name, nx_u_name }, &fill_value);
         ncf.var("u").put_attr("long_name","u-momentum component");
@@ -1164,63 +1132,31 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             // **************************************************************************
 
             // **************************************************************************
-            // Horizontal mixing coefficients:
-            // - For scaled_to_grid: treat as time-invariant and write only once (header creation).
-            // - Otherwise: write as time series like other 3D fields.
+            // Horizontal mixing coefficients (scaled_to_grid):
+            // vertically homogeneous and time-invariant -> write static 2D fields once.
             // **************************************************************************
-            const bool coeffs_are_time_invariant =
-                (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid);
-            const bool should_write_static_coeffs = (!coeffs_are_time_invariant) || write_header;
+            if ((solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) && write_header) {
+                { // visc2 (k=0 plane)
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_visc2_r[lev])[mfi.index()], 0, 0, 1);
+                    Gpu::streamSynchronize();
 
-            if (should_write_static_coeffs) {
-                { // visc2
-                    int comp = -1;
-                    for (int i = 0; i < plot_var_names_3d.size(); i++) {
-                        if (plot_var_names_3d[i] == "visc2") comp = i;
-                    }
-                    if (comp >= 0) {
-                        FArrayBox tmp;
-                        tmp.resize(tmp_bx, 1, amrex::The_Pinned_Arena());
-                        tmp.template copy<RunOn::Device>((*plotMF)[mfi.index()], comp, 0, 1);
-                        Gpu::streamSynchronize();
+                    auto nc_var = ncf.var("visc2");
+                    nc_var.put(tmp.dataPtr(), { local_start_y, local_start_x }, { local_ny, local_nx });
+                }
 
-                        auto nc_plot_var = ncf.var(plot_var_names_3d[comp]);
-                        if (coeffs_are_time_invariant) {
-                            nc_plot_var.put(tmp.dataPtr(),
-                                            { local_start_z, local_start_y, local_start_x },
-                                            { local_nz,      local_ny,      local_nx });
-                        } else {
-                            nc_plot_var.put(tmp.dataPtr(),
-                                            { local_start_nt, local_start_z, local_start_y, local_start_x },
-                                            { local_nt,       local_nz,      local_ny,      local_nx });
-                        }
-                    }
-                } // visc2
-
+                // diff2_* (k=0 plane)
                 for (int n = 0; n < NCONS; ++n) {
                     const std::string nm = std::string("diff2_") + cons_names[n];
-                    int comp = -1;
-                    for (int i = 0; i < plot_var_names_3d.size(); i++) {
-                        if (plot_var_names_3d[i] == nm) comp = i;
-                    }
-                    if (comp >= 0) {
-                        FArrayBox tmp;
-                        tmp.resize(tmp_bx, 1, amrex::The_Pinned_Arena());
-                        tmp.template copy<RunOn::Device>((*plotMF)[mfi.index()], comp, 0, 1);
-                        Gpu::streamSynchronize();
+                    FArrayBox tmp;
+                    tmp.resize(tmp_bx_2d, 1, amrex::The_Pinned_Arena());
+                    tmp.template copy<RunOn::Device>((*vec_diff2[lev])[mfi.index()], n, 0, 1);
+                    Gpu::streamSynchronize();
 
-                        auto nc_plot_var = ncf.var(plot_var_names_3d[comp]);
-                        if (coeffs_are_time_invariant) {
-                            nc_plot_var.put(tmp.dataPtr(),
-                                            { local_start_z, local_start_y, local_start_x },
-                                            { local_nz,      local_ny,      local_nx });
-                        } else {
-                            nc_plot_var.put(tmp.dataPtr(),
-                                            { local_start_nt, local_start_z, local_start_y, local_start_x },
-                                            { local_nt,       local_nz,      local_ny,      local_nx });
-                        }
-                    }
-                } // diff2_*
+                    auto nc_var = ncf.var(nm);
+                    nc_var.put(tmp.dataPtr(), { local_start_y, local_start_x }, { local_ny, local_nx });
+                }
             }
 
         } // subdomain

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -435,7 +435,6 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             }
         }
 
-        ncf.def_var_fill("u", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_u_name, nx_u_name }, &fill_value);
         ncf.def_var_fill("u", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_u_name, nx_u_name }, &netcdf_fill_value);
         ncf.var("u").put_attr("long_name","u-momentum component");
         ncf.var("u").put_attr("units","meter second-1");

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -412,10 +412,9 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             }
         } // end vorticity
 
-        // Horizontal mixing coefficients are vertically homogeneous. For scaled_to_grid we output
-        // them as static 2D rho-point fields (no ocean_time, no s_rho).
+        // Output 2D horizontal mixing coefficients if using scaled_to_grid option
         if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-            ncf.def_var_fill("visc2", ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &fill_value);
+            ncf.def_var_fill("visc2", ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &netcdf_fill_value);
             ncf.var("visc2").put_attr("long_name","horizontal harmonic viscosity coefficient at RHO-points");
             ncf.var("visc2").put_attr("units","meter2 second-1");
             ncf.var("visc2").put_attr("grid","grid");
@@ -425,7 +424,7 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
 
             for (int n = 0; n < NCONS; ++n) {
                 const std::string nm = std::string("diff2_") + cons_names[n];
-                ncf.def_var_fill(nm, ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &fill_value);
+                ncf.def_var_fill(nm, ncutils::NCDType::Real, { ny_r_name, nx_r_name }, &netcdf_fill_value);
                 ncf.var(nm).put_attr("long_name", std::string("horizontal harmonic diffusivity coefficient for ") + cons_names[n] + " at RHO-points");
                 ncf.var(nm).put_attr("units","meter2 second-1");
                 ncf.var(nm).put_attr("grid","grid");

--- a/Source/IO/REMORA_NCPlotFile.cpp
+++ b/Source/IO/REMORA_NCPlotFile.cpp
@@ -414,6 +414,61 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             }
         } // end vorticity
 
+        {
+            int comp = -1;
+            for (int i = 0; i < plot_var_names_3d.size(); i++) {
+                if (plot_var_names_3d[i] == "visc2") comp = i;
+            }
+            if (comp >= 0) {
+                // For scaled_to_grid, viscosity is time-invariant; write it as a static variable
+                // without an ocean_time dimension (and only write it once per file).
+                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+                    ncf.def_var_fill("visc2", ncutils::NCDType::Real, { nz_r_name, ny_r_name, nx_r_name }, &fill_value);
+                } else {
+                    ncf.def_var_fill("visc2", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_r_name, nx_r_name }, &fill_value);
+                }
+                ncf.var("visc2").put_attr("long_name","horizontal harmonic viscosity coefficient at RHO-points");
+                ncf.var("visc2").put_attr("units","meter2 second-1");
+                ncf.var("visc2").put_attr("grid","grid");
+                ncf.var("visc2").put_attr("location","face");
+                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+                    ncf.var("visc2").put_attr("coordinates","x_rho y_rho s_rho");
+                    ncf.var("visc2").put_attr("field","visc2, scalar");
+                } else {
+                    ncf.var("visc2").put_attr("time","ocean_time");
+                    ncf.var("visc2").put_attr("coordinates","x_rho y_rho s_rho ocean_time");
+                    ncf.var("visc2").put_attr("field","visc2, scalar, series");
+                }
+            }
+        } // end visc2
+
+        for (int n = 0; n < NCONS; ++n) {
+            const std::string nm = std::string("diff2_") + cons_names[n];
+            int comp = -1;
+            for (int i = 0; i < plot_var_names_3d.size(); i++) {
+                if (plot_var_names_3d[i] == nm) comp = i;
+            }
+            if (comp >= 0) {
+                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+                    ncf.def_var_fill(nm, ncutils::NCDType::Real, { nz_r_name, ny_r_name, nx_r_name }, &fill_value);
+                } else {
+                    ncf.def_var_fill(nm, ncutils::NCDType::Real, { nt_name, nz_r_name, ny_r_name, nx_r_name }, &fill_value);
+                }
+                ncf.var(nm).put_attr("long_name", std::string("horizontal harmonic diffusivity coefficient for ") + cons_names[n] + " at RHO-points");
+                ncf.var(nm).put_attr("units","meter2 second-1");
+                ncf.var(nm).put_attr("grid","grid");
+                ncf.var(nm).put_attr("location","face");
+                if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+                    ncf.var(nm).put_attr("coordinates","x_rho y_rho s_rho");
+                    ncf.var(nm).put_attr("field", nm + ", scalar");
+                } else {
+                    ncf.var(nm).put_attr("time","ocean_time");
+                    ncf.var(nm).put_attr("coordinates","x_rho y_rho s_rho ocean_time");
+                    ncf.var(nm).put_attr("field", nm + ", scalar, series");
+                }
+            }
+        } // end diff2_*
+
         ncf.def_var_fill("u", ncutils::NCDType::Real, { nt_name, nz_r_name, ny_u_name, nx_u_name }, &fill_value);
         ncf.var("u").put_attr("long_name","u-momentum component");
         ncf.var("u").put_attr("units","meter second-1");
@@ -1108,6 +1163,66 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
             } // end vorticity
             // **************************************************************************
 
+            // **************************************************************************
+            // Horizontal mixing coefficients:
+            // - For scaled_to_grid: treat as time-invariant and write only once (header creation).
+            // - Otherwise: write as time series like other 3D fields.
+            // **************************************************************************
+            const bool coeffs_are_time_invariant =
+                (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid);
+            const bool should_write_static_coeffs = (!coeffs_are_time_invariant) || write_header;
+
+            if (should_write_static_coeffs) {
+                { // visc2
+                    int comp = -1;
+                    for (int i = 0; i < plot_var_names_3d.size(); i++) {
+                        if (plot_var_names_3d[i] == "visc2") comp = i;
+                    }
+                    if (comp >= 0) {
+                        FArrayBox tmp;
+                        tmp.resize(tmp_bx, 1, amrex::The_Pinned_Arena());
+                        tmp.template copy<RunOn::Device>((*plotMF)[mfi.index()], comp, 0, 1);
+                        Gpu::streamSynchronize();
+
+                        auto nc_plot_var = ncf.var(plot_var_names_3d[comp]);
+                        if (coeffs_are_time_invariant) {
+                            nc_plot_var.put(tmp.dataPtr(),
+                                            { local_start_z, local_start_y, local_start_x },
+                                            { local_nz,      local_ny,      local_nx });
+                        } else {
+                            nc_plot_var.put(tmp.dataPtr(),
+                                            { local_start_nt, local_start_z, local_start_y, local_start_x },
+                                            { local_nt,       local_nz,      local_ny,      local_nx });
+                        }
+                    }
+                } // visc2
+
+                for (int n = 0; n < NCONS; ++n) {
+                    const std::string nm = std::string("diff2_") + cons_names[n];
+                    int comp = -1;
+                    for (int i = 0; i < plot_var_names_3d.size(); i++) {
+                        if (plot_var_names_3d[i] == nm) comp = i;
+                    }
+                    if (comp >= 0) {
+                        FArrayBox tmp;
+                        tmp.resize(tmp_bx, 1, amrex::The_Pinned_Arena());
+                        tmp.template copy<RunOn::Device>((*plotMF)[mfi.index()], comp, 0, 1);
+                        Gpu::streamSynchronize();
+
+                        auto nc_plot_var = ncf.var(plot_var_names_3d[comp]);
+                        if (coeffs_are_time_invariant) {
+                            nc_plot_var.put(tmp.dataPtr(),
+                                            { local_start_z, local_start_y, local_start_x },
+                                            { local_nz,      local_ny,      local_nx });
+                        } else {
+                            nc_plot_var.put(tmp.dataPtr(),
+                                            { local_start_nt, local_start_z, local_start_y, local_start_x },
+                                            { local_nt,       local_nz,      local_ny,      local_nx });
+                        }
+                    }
+                } // diff2_*
+            }
+
         } // subdomain
     } // mfi
 
@@ -1343,4 +1458,3 @@ void REMORA::WriteNCPlotFile_which(int lev, int which_subdomain, MultiFab const*
 
     REMORA::total_nc_plot_file_step += 1;
 }
-

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -21,28 +21,32 @@ REMORA::WritePlotFile (int istep_for_plot)
     Vector<std::string> varnames_3d;
     varnames_3d.insert(varnames_3d.end(), plot_var_names_3d.begin(), plot_var_names_3d.end());
 
-    // For scaled_to_grid, horizontal mixing coefficients are time-invariant. For AMReX plotfiles,
-    // write them once to a dedicated static plotfile and omit them from regular time-series plotfiles.
-    Vector<std::string> varnames_3d_coeff;
+    Vector<std::string> varnames_2d;
+    varnames_2d.insert(varnames_2d.end(), plot_var_names_2d.begin(), plot_var_names_2d.end());
+
+    // For scaled_to_grid, viscosity/diffusivity coefficients are vertically homogeneous and
+    // time-invariant. For AMReX plotfiles, write them once to a dedicated static plotfile and
+    // omit them from regular time-series plotfiles.
+    Vector<std::string> varnames_2d_coeff;
     const bool write_static_coeff_plotfile =
         (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) &&
         (plotfile_type == PlotfileType::amrex);
 
     if (write_static_coeff_plotfile) {
-        for (auto const& nm : varnames_3d) {
+        for (auto const& nm : varnames_2d) {
             if (nm == "visc2") {
-                varnames_3d_coeff.push_back(nm);
+                varnames_2d_coeff.push_back(nm);
                 continue;
             }
             for (int n = 0; n < NCONS; ++n) {
                 if (nm == std::string("diff2_") + cons_names[n]) {
-                    varnames_3d_coeff.push_back(nm);
+                    varnames_2d_coeff.push_back(nm);
                     break;
                 }
             }
         }
 
-        varnames_3d.erase(std::remove_if(varnames_3d.begin(), varnames_3d.end(),
+        varnames_2d.erase(std::remove_if(varnames_2d.begin(), varnames_2d.end(),
                                          [&] (std::string const& nm) {
                                              if (nm == "visc2") { return true; }
                                              for (int n = 0; n < NCONS; ++n) {
@@ -50,18 +54,14 @@ REMORA::WritePlotFile (int istep_for_plot)
                                              }
                                              return false;
                                          }),
-                          varnames_3d.end());
+                          varnames_2d.end());
     }
-
-    Vector<std::string> varnames_2d;
-    varnames_2d.insert(varnames_2d.end(), plot_var_names_2d.begin(), plot_var_names_2d.end());
 
     Vector<std::string> varnames_2d_rho;
     Vector<std::string> varnames_2d_u;
     Vector<std::string> varnames_2d_v;
 
     const int ncomp_mf_3d = varnames_3d.size();
-    const int ncomp_mf_3d_coeff = varnames_3d_coeff.size();
     const auto ngrow_vars = IntVect(NGROW-1,NGROW-1,0);
 
     // These are the ncomp for the 2D cell-centered, x-face-based, y-face-based MultiFabs respectively
@@ -74,6 +74,10 @@ REMORA::WritePlotFile (int istep_for_plot)
       {
          if (plot_name == "zeta" ) {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
          if (plot_name == "h"    ) {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
+         if (plot_name == "visc2") {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
+         if (plot_name == "diff2_temp"  ) {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
+         if (plot_name == "diff2_salt"  ) {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
+         if (plot_name == "diff2_tracer") {varnames_2d_rho.push_back(plot_name); ncomp_mf_2d_rho++;}
          if (plot_name == "ubar" ) {varnames_2d_u.push_back(plot_name); ncomp_mf_2d_u++;}
          if (plot_name == "sustr") {varnames_2d_u.push_back(plot_name); ncomp_mf_2d_u++;}
          if (plot_name == "bustr") {varnames_2d_u.push_back(plot_name); ncomp_mf_2d_u++;}
@@ -108,16 +112,6 @@ REMORA::WritePlotFile (int istep_for_plot)
         plotMF[lev].setVal(1.234e20);
     }
 
-    // 3D MultiFabs to hold time-invariant coefficient fields (written once)
-    Vector<MultiFab> plotMF_coeff;
-    if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
-        plotMF_coeff.resize(finest_level+1);
-        for (int lev = 0; lev <= finest_level; ++lev) {
-            plotMF_coeff[lev].define(grids[lev], dmap[lev], ncomp_mf_3d_coeff, ngrow_vars);
-            plotMF_coeff[lev].setVal(1.234e20);
-        }
-    }
-
     // Array of 2D MultiFabs to hold the plotfile data
     Vector<MultiFab> mf_2d_rho(finest_level+1);
     Vector<MultiFab> mf_2d_u(finest_level+1);
@@ -134,20 +128,27 @@ REMORA::WritePlotFile (int istep_for_plot)
           mf_2d_v[lev].define(ba2d, dmap[lev], ncomp_mf_2d_v  , IntVect(0,0,0));
     }
 
-    // Empty 2D MultiFabs for the static coefficient plotfile
-    Vector<MultiFab> mf_2d_rho_zero;
+    // Static coefficient plotfile (2D rho-point fields, written once)
+    const int ncomp_mf_2d_rho_coeff = static_cast<int>(varnames_2d_coeff.size());
+    Vector<MultiFab> plotMF_zero;
+    Vector<MultiFab> mf_2d_rho_coeff;
     Vector<MultiFab> mf_2d_u_zero;
     Vector<MultiFab> mf_2d_v_zero;
-    if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
-        mf_2d_rho_zero.resize(finest_level+1);
+    if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+        plotMF_zero.resize(finest_level+1);
+        mf_2d_rho_coeff.resize(finest_level+1);
         mf_2d_u_zero.resize(finest_level+1);
         mf_2d_v_zero.resize(finest_level+1);
         for (int lev = 0; lev <= finest_level; ++lev) {
+            // 3D plot MF with zero components
+            plotMF_zero[lev].define(grids[lev], dmap[lev], 0, IntVect(0,0,0));
+
             BoxArray ba(grids[lev]);
             BoxList bl2d = ba.boxList();
             for (auto& b : bl2d) { b.setRange(2,0); }
             BoxArray ba2d(std::move(bl2d));
-            mf_2d_rho_zero[lev].define(ba2d, dmap[lev], 0, IntVect(0,0,0));
+
+            mf_2d_rho_coeff[lev].define(ba2d, dmap[lev], ncomp_mf_2d_rho_coeff, IntVect(0,0,0));
             mf_2d_u_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
             mf_2d_v_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
         }
@@ -224,6 +225,65 @@ REMORA::WritePlotFile (int istep_for_plot)
              for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_rho[lev],*vec_h[lev],0,icomp_rho,1,0); }
              icomp_rho++;
          }
+         if (plot_name == "visc2" ) {
+             for (int lev = 0; lev <= finest_level; ++lev) {
+                 if (vec_visc2_r[lev]->contains_nan(0, 1, 0, true) || vec_visc2_r[lev]->contains_inf(0, 1, 0, true)) {
+                     amrex::Abort("Found while writing output: visc2 contains nan or inf");
+                 }
+                 for (MFIter mfi(mf_2d_rho[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                     const Box& bx = mfi.validbox();
+                     const int K = mfi.index();
+                     auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
+                     auto src = vec_visc2_r[lev]->const_array(K);
+                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                         dst(i,j,k) = src(i,j,0,0);
+                     });
+                 }
+             }
+             icomp_rho++;
+         }
+         if (plot_name == "diff2_temp" ) {
+             for (int lev = 0; lev <= finest_level; ++lev) {
+                 for (MFIter mfi(mf_2d_rho[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                     const Box& bx = mfi.validbox();
+                     const int K = mfi.index();
+                     auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
+                     auto src = vec_diff2[lev]->const_array(K);
+                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                         dst(i,j,k) = src(i,j,0,Temp_comp);
+                     });
+                 }
+             }
+             icomp_rho++;
+         }
+         if (plot_name == "diff2_salt" ) {
+             for (int lev = 0; lev <= finest_level; ++lev) {
+                 for (MFIter mfi(mf_2d_rho[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                     const Box& bx = mfi.validbox();
+                     const int K = mfi.index();
+                     auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
+                     auto src = vec_diff2[lev]->const_array(K);
+                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                         dst(i,j,k) = src(i,j,0,Salt_comp);
+                     });
+                 }
+             }
+             icomp_rho++;
+         }
+         if (plot_name == "diff2_tracer" ) {
+             for (int lev = 0; lev <= finest_level; ++lev) {
+                 for (MFIter mfi(mf_2d_rho[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                     const Box& bx = mfi.validbox();
+                     const int K = mfi.index();
+                     auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
+                     auto src = vec_diff2[lev]->const_array(K);
+                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                         dst(i,j,k) = src(i,j,0,Tracer_comp);
+                     });
+                 }
+             }
+             icomp_rho++;
+         }
     }
 
     int icomp_u   = 0;
@@ -260,6 +320,73 @@ REMORA::WritePlotFile (int istep_for_plot)
              for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_v[lev],*vec_bvstr[lev],0,icomp_v,1,0); }
              icomp_v++;
          }
+    }
+
+    // Fill the time-invariant coefficient plotfile (2D rho points) if enabled
+    if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+        int icomp_coeff = 0;
+        for (auto const& nm : varnames_2d_coeff) {
+            if (nm == "visc2") {
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                        const Box& bx = mfi.validbox();
+                        const int K = mfi.index();
+                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
+                        auto src = vec_visc2_r[lev]->const_array(K);
+                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            dst(i,j,k) = src(i,j,0,0);
+                        });
+                    }
+                }
+                icomp_coeff++;
+                continue;
+            }
+            if (nm == "diff2_temp") {
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                        const Box& bx = mfi.validbox();
+                        const int K = mfi.index();
+                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
+                        auto src = vec_diff2[lev]->const_array(K);
+                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            dst(i,j,k) = src(i,j,0,Temp_comp);
+                        });
+                    }
+                }
+                icomp_coeff++;
+                continue;
+            }
+            if (nm == "diff2_salt") {
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                        const Box& bx = mfi.validbox();
+                        const int K = mfi.index();
+                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
+                        auto src = vec_diff2[lev]->const_array(K);
+                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            dst(i,j,k) = src(i,j,0,Salt_comp);
+                        });
+                    }
+                }
+                icomp_coeff++;
+                continue;
+            }
+            if (nm == "diff2_tracer") {
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                        const Box& bx = mfi.validbox();
+                        const int K = mfi.index();
+                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
+                        auto src = vec_diff2[lev]->const_array(K);
+                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            dst(i,j,k) = src(i,j,0,Tracer_comp);
+                        });
+                    }
+                }
+                icomp_coeff++;
+                continue;
+            }
+        }
     }
 
     for (int lev = 0; lev <= finest_level; ++lev)
@@ -361,42 +488,6 @@ REMORA::WritePlotFile (int istep_for_plot)
             mf_comp += AMREX_SPACEDIM;
         } // if containerHasElement
 
-        // Horizontal mixing coefficients (rho points) written into the time-series plotfile
-        if (containerHasElement(varnames_3d, "visc2")) {
-            if (vec_visc2_r[lev]->contains_nan(0, 1, 0, true) || vec_visc2_r[lev]->contains_inf(0, 1, 0, true)) {
-                amrex::Abort("Found while writing output: visc2 contains nan or inf");
-            }
-            MultiFab::Copy(plotMF[lev], *vec_visc2_r[lev], 0, mf_comp, 1, ngrow_vars);
-            mf_comp += 1;
-        }
-
-        for (int n = 0; n < NCONS; ++n) {
-            const std::string nm = std::string("diff2_") + cons_names[n];
-            if (containerHasElement(varnames_3d, nm)) {
-                if (vec_diff2[lev]->contains_nan(n, 1, 0, true) || vec_diff2[lev]->contains_inf(n, 1, 0, true)) {
-                    amrex::Abort("Found while writing output: diff2 contains nan or inf");
-                }
-                MultiFab::Copy(plotMF[lev], *vec_diff2[lev], n, mf_comp, 1, ngrow_vars);
-                mf_comp += 1;
-            }
-        }
-
-        // Time-invariant coefficient plotfile for scaled_to_grid
-        if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
-            int cf_comp = 0;
-            if (containerHasElement(varnames_3d_coeff, "visc2")) {
-                MultiFab::Copy(plotMF_coeff[lev], *vec_visc2_r[lev], 0, cf_comp, 1, ngrow_vars);
-                cf_comp += 1;
-            }
-            for (int n = 0; n < NCONS; ++n) {
-                const std::string nm = std::string("diff2_") + cons_names[n];
-                if (containerHasElement(varnames_3d_coeff, nm)) {
-                    MultiFab::Copy(plotMF_coeff[lev], *vec_diff2[lev], n, cf_comp, 1, ngrow_vars);
-                    cf_comp += 1;
-                }
-            }
-        }
-
 #ifdef REMORA_USE_PARTICLES
         const auto& particles_namelist( particleData.getNames() );
         for (ParticlesNamesVector::size_type i = 0; i < particles_namelist.size(); i++) {
@@ -451,25 +542,26 @@ REMORA::WritePlotFile (int istep_for_plot)
     if (finest_level == 0)
     {
         if (plotfile_type == PlotfileType::amrex) {
-            if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+            if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
                 const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
                 if (!amrex::FileExists(coeff_plotfilename)) {
                     amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
                                    << coeff_plotfilename << "\n";
                     Vector<int> level_steps_zero = istep;
                     for (auto& s : level_steps_zero) { s = 0; }
+                    Vector<std::string> empty_3d;
                     Vector<std::string> empty_2d;
                     WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                          GetVecOfConstPtrs(plotMF_coeff),
+                                                          GetVecOfConstPtrs(plotMF_zero),
                                                           GetVecOfConstPtrs(mf_nd),
                                                           GetVecOfConstPtrs(mf_u),
                                                           GetVecOfConstPtrs(mf_v),
                                                           GetVecOfConstPtrs(mf_w),
-                                                          GetVecOfConstPtrs(mf_2d_rho_zero),
+                                                          GetVecOfConstPtrs(mf_2d_rho_coeff),
                                                           GetVecOfConstPtrs(mf_2d_u_zero),
                                                           GetVecOfConstPtrs(mf_2d_v_zero),
-                                                          varnames_3d_coeff,
-                                                          empty_2d, empty_2d, empty_2d,
+                                                          empty_3d,
+                                                          varnames_2d_coeff, empty_2d, empty_2d,
                                                           Geom(),
                                                           0.0_rt, level_steps_zero, refRatio());
                     writeJobInfo(coeff_plotfilename);
@@ -507,25 +599,26 @@ REMORA::WritePlotFile (int istep_for_plot)
 
     } else { // multilevel
         if (plotfile_type == PlotfileType::amrex) {
-            if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+            if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
                 const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
                 if (!amrex::FileExists(coeff_plotfilename)) {
                     amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
                                    << coeff_plotfilename << "\n";
                     Vector<int> level_steps_zero = istep;
                     for (auto& s : level_steps_zero) { s = 0; }
+                    Vector<std::string> empty_3d;
                     Vector<std::string> empty_2d;
                     WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                          GetVecOfConstPtrs(plotMF_coeff),
+                                                          GetVecOfConstPtrs(plotMF_zero),
                                                           GetVecOfConstPtrs(mf_nd),
                                                           GetVecOfConstPtrs(mf_u),
                                                           GetVecOfConstPtrs(mf_v),
                                                           GetVecOfConstPtrs(mf_w),
-                                                          GetVecOfConstPtrs(mf_2d_rho_zero),
+                                                          GetVecOfConstPtrs(mf_2d_rho_coeff),
                                                           GetVecOfConstPtrs(mf_2d_u_zero),
                                                           GetVecOfConstPtrs(mf_2d_v_zero),
-                                                          varnames_3d_coeff,
-                                                          empty_2d, empty_2d, empty_2d,
+                                                          empty_3d,
+                                                          varnames_2d_coeff, empty_2d, empty_2d,
                                                           Geom(),
                                                           0.0_rt, level_steps_zero, ref_ratio);
                     writeJobInfo(coeff_plotfilename);

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -261,7 +261,6 @@ REMORA::WritePlotFile (int istep_for_plot)
          }
     }
 
-
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         int mf_comp = 0;
@@ -403,8 +402,6 @@ REMORA::WritePlotFile (int istep_for_plot)
                 mf_arr(i,j,k,2) = mf_arr(i,j,k,2) + (N-k) * dz;
             });
         } // mfi
-
-
     } // lev
 
     if ( (plotfile_type == PlotfileType::amrex) ||
@@ -415,7 +412,7 @@ REMORA::WritePlotFile (int istep_for_plot)
 
     if (finest_level == 0)
     {
-            if (plotfile_type == PlotfileType::amrex) {
+        if (plotfile_type == PlotfileType::amrex) {
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             WriteMultiLevelPlotfileWithBathymetry(plotfilename, finest_level+1,
                                                   GetVecOfConstPtrs(plotMF),
@@ -447,7 +444,7 @@ REMORA::WritePlotFile (int istep_for_plot)
         }
 
     } else { // multilevel
-            if (plotfile_type == PlotfileType::amrex) {
+        if (plotfile_type == PlotfileType::amrex) {
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             int lev0 = 0;
             [[maybe_unused]] int desired_ratio = std::max(std::max(ref_ratio[lev0][0],ref_ratio[lev0][1]),ref_ratio[lev0][2]);
@@ -941,9 +938,6 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where)
                 salt(i,j,k) = fill_value;
             }
         });
-        // visc2/diff2 are stored as horizontally-varying only (nz==1).
-        // Only touch the k==0 slab here to avoid out-of-bounds writes when
-        // these MultiFabs have a single vertical layer.
         ParallelFor(makeSlab(gbx_coeff,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int )
         {
             if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -25,14 +25,15 @@ REMORA::WritePlotFile (int istep_for_plot)
     varnames_2d.insert(varnames_2d.end(), plot_var_names_2d.begin(), plot_var_names_2d.end());
 
     // For scaled_to_grid, viscosity/diffusivity coefficients are vertically homogeneous and
-    // time-invariant. For AMReX plotfiles, write them once to a dedicated static plotfile and
-    // omit them from regular time-series plotfiles.
+    // time-invariant. For AMReX plotfiles, write them to a dedicated coefficient plotfile and
+    // omit them from regular time-series plotfiles. For AMR, we write a coefficient plotfile
+    // per plot output so it matches the current grid hierarchy.
     Vector<std::string> varnames_2d_coeff;
-    const bool write_static_coeff_plotfile =
+    const bool write_coeff_plotfile =
         (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) &&
         (plotfile_type == PlotfileType::amrex);
 
-    if (write_static_coeff_plotfile) {
+    if (write_coeff_plotfile) {
         for (auto const& nm : varnames_2d) {
             if (nm == "visc2") {
                 varnames_2d_coeff.push_back(nm);
@@ -128,29 +129,51 @@ REMORA::WritePlotFile (int istep_for_plot)
           mf_2d_v[lev].define(ba2d, dmap[lev], ncomp_mf_2d_v  , IntVect(0,0,0));
     }
 
-    // Static coefficient plotfile (2D rho-point fields, written once)
+    // Coefficient plotfile (2D rho-point fields).
+    //
+    // NOTE: REMORA/AMReX is built in 3D (AMREX_SPACEDIM=3). For coefficient output we write a
+    // k=0 slab (nz=1) so downstream tools see these fields as 2D (or 3D with a singleton z).
     const int ncomp_mf_2d_rho_coeff = static_cast<int>(varnames_2d_coeff.size());
     Vector<MultiFab> plotMF_zero;
     Vector<MultiFab> mf_2d_rho_coeff;
     Vector<MultiFab> mf_2d_u_zero;
     Vector<MultiFab> mf_2d_v_zero;
-    if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+    Vector<MultiFab> mf_nd_coeff;
+    Vector<Geometry> geom_coeff;
+    if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
         plotMF_zero.resize(finest_level+1);
         mf_2d_rho_coeff.resize(finest_level+1);
         mf_2d_u_zero.resize(finest_level+1);
         mf_2d_v_zero.resize(finest_level+1);
+        mf_nd_coeff.resize(finest_level+1);
+        geom_coeff.resize(finest_level+1);
         for (int lev = 0; lev <= finest_level; ++lev) {
-            // 3D plot MF with zero components
-            plotMF_zero[lev].define(grids[lev], dmap[lev], 0, IntVect(0,0,0));
-
+            // Build a k=0 slab BoxArray for 2D coefficient output.
             BoxArray ba(grids[lev]);
             BoxList bl2d = ba.boxList();
             for (auto& b : bl2d) { b.setRange(2,0); }
             BoxArray ba2d(std::move(bl2d));
 
+            // "3D" plot MF with zero components, defined on the slab BoxArray so the plotfile
+            // header describes a 2D (nz=1) hierarchy.
+            plotMF_zero[lev].define(ba2d, dmap[lev], 0, IntVect(0,0,0));
+
             mf_2d_rho_coeff[lev].define(ba2d, dmap[lev], ncomp_mf_2d_rho_coeff, IntVect(0,0,0));
             mf_2d_u_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
             mf_2d_v_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
+
+            // Nodal coordinates for the coefficient plotfile, also on the slab hierarchy.
+            BoxArray nodal_grids(ba2d);
+            nodal_grids.surroundingNodes();
+            mf_nd_coeff[lev].define(nodal_grids, dmap[lev], AMREX_SPACEDIM, 0);
+            mf_nd_coeff[lev].setVal(0.0_rt);
+
+            // Geometry for the coefficient plotfile: use a z-slab domain (nz=1).
+            Box dom2d = Geom()[lev].Domain();
+            dom2d.setRange(2,0);
+            Array<int,AMREX_SPACEDIM> periodicity =
+                {Geom()[lev].isPeriodic(0),Geom()[lev].isPeriodic(1),Geom()[lev].isPeriodic(2)};
+            geom_coeff[lev].define(dom2d, &(Geom()[lev].ProbDomain()), Geom()[lev].Coord(), periodicity.data());
         }
     }
 
@@ -323,7 +346,7 @@ REMORA::WritePlotFile (int istep_for_plot)
     }
 
     // Fill the time-invariant coefficient plotfile (2D rho points) if enabled
-    if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+    if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
         int icomp_coeff = 0;
         for (auto const& nm : varnames_2d_coeff) {
             if (nm == "visc2") {
@@ -531,6 +554,19 @@ REMORA::WritePlotFile (int istep_for_plot)
             });
         } // mfi
 
+        // Fill the coefficient plotfile nodal z coordinate (k=0 slab) if enabled.
+        if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+            for (MFIter mfi(mf_nd_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                Array4<Real> mf_arr = mf_nd_coeff[lev].array(mfi);
+                Array4<Real const> zp_arr = vec_z_phys_nd[lev]->const_array(mfi);
+                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    mf_arr(i,j,k,2) = zp_arr(i,j,k) + (N-k) * dz;
+                });
+            }
+        }
+
     } // lev
 
     if ( (plotfile_type == PlotfileType::amrex) ||
@@ -542,30 +578,26 @@ REMORA::WritePlotFile (int istep_for_plot)
     if (finest_level == 0)
     {
         if (plotfile_type == PlotfileType::amrex) {
-            if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-                const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
-                if (!amrex::FileExists(coeff_plotfilename)) {
-                    amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
-                                   << coeff_plotfilename << "\n";
-                    Vector<int> level_steps_zero = istep;
-                    for (auto& s : level_steps_zero) { s = 0; }
-                    Vector<std::string> empty_3d;
-                    Vector<std::string> empty_2d;
-                    WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                          GetVecOfConstPtrs(plotMF_zero),
-                                                          GetVecOfConstPtrs(mf_nd),
-                                                          GetVecOfConstPtrs(mf_u),
-                                                          GetVecOfConstPtrs(mf_v),
-                                                          GetVecOfConstPtrs(mf_w),
-                                                          GetVecOfConstPtrs(mf_2d_rho_coeff),
-                                                          GetVecOfConstPtrs(mf_2d_u_zero),
-                                                          GetVecOfConstPtrs(mf_2d_v_zero),
-                                                          empty_3d,
-                                                          varnames_2d_coeff, empty_2d, empty_2d,
-                                                          Geom(),
-                                                          0.0_rt, level_steps_zero, refRatio());
-                    writeJobInfo(coeff_plotfilename);
-                }
+            if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+                const std::string coeff_plotfilename = plotfilename + "_hmixcoef";
+                amrex::Print() << "Writing horizontal mixing coefficient plotfile "
+                               << coeff_plotfilename << "\n";
+                Vector<std::string> empty_3d;
+                Vector<std::string> empty_2d;
+                WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
+                                                      GetVecOfConstPtrs(plotMF_zero),
+                                                      GetVecOfConstPtrs(mf_nd_coeff),
+                                                      GetVecOfConstPtrs(mf_u),
+                                                      GetVecOfConstPtrs(mf_v),
+                                                      GetVecOfConstPtrs(mf_w),
+                                                      GetVecOfConstPtrs(mf_2d_rho_coeff),
+                                                      GetVecOfConstPtrs(mf_2d_u_zero),
+                                                      GetVecOfConstPtrs(mf_2d_v_zero),
+                                                      empty_3d,
+                                                      varnames_2d_coeff, empty_2d, empty_2d,
+                                                      geom_coeff,
+                                                      t_new[0], istep, refRatio());
+                writeJobInfo(coeff_plotfilename);
             }
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             WriteMultiLevelPlotfileWithBathymetry(plotfilename, finest_level+1,
@@ -599,30 +631,26 @@ REMORA::WritePlotFile (int istep_for_plot)
 
     } else { // multilevel
         if (plotfile_type == PlotfileType::amrex) {
-            if (write_static_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-                const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
-                if (!amrex::FileExists(coeff_plotfilename)) {
-                    amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
-                                   << coeff_plotfilename << "\n";
-                    Vector<int> level_steps_zero = istep;
-                    for (auto& s : level_steps_zero) { s = 0; }
-                    Vector<std::string> empty_3d;
-                    Vector<std::string> empty_2d;
-                    WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                          GetVecOfConstPtrs(plotMF_zero),
-                                                          GetVecOfConstPtrs(mf_nd),
-                                                          GetVecOfConstPtrs(mf_u),
-                                                          GetVecOfConstPtrs(mf_v),
-                                                          GetVecOfConstPtrs(mf_w),
-                                                          GetVecOfConstPtrs(mf_2d_rho_coeff),
-                                                          GetVecOfConstPtrs(mf_2d_u_zero),
-                                                          GetVecOfConstPtrs(mf_2d_v_zero),
-                                                          empty_3d,
-                                                          varnames_2d_coeff, empty_2d, empty_2d,
-                                                          Geom(),
-                                                          0.0_rt, level_steps_zero, ref_ratio);
-                    writeJobInfo(coeff_plotfilename);
-                }
+            if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
+                const std::string coeff_plotfilename = plotfilename + "_hmixcoef";
+                amrex::Print() << "Writing horizontal mixing coefficient plotfile "
+                               << coeff_plotfilename << "\n";
+                Vector<std::string> empty_3d;
+                Vector<std::string> empty_2d;
+                WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
+                                                      GetVecOfConstPtrs(plotMF_zero),
+                                                      GetVecOfConstPtrs(mf_nd_coeff),
+                                                      GetVecOfConstPtrs(mf_u),
+                                                      GetVecOfConstPtrs(mf_v),
+                                                      GetVecOfConstPtrs(mf_w),
+                                                      GetVecOfConstPtrs(mf_2d_rho_coeff),
+                                                      GetVecOfConstPtrs(mf_2d_u_zero),
+                                                      GetVecOfConstPtrs(mf_2d_v_zero),
+                                                      empty_3d,
+                                                      varnames_2d_coeff, empty_2d, empty_2d,
+                                                      geom_coeff,
+                                                      t_new[0], istep, ref_ratio);
+                writeJobInfo(coeff_plotfilename);
             }
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             int lev0 = 0;

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -24,40 +24,6 @@ REMORA::WritePlotFile (int istep_for_plot)
     Vector<std::string> varnames_2d;
     varnames_2d.insert(varnames_2d.end(), plot_var_names_2d.begin(), plot_var_names_2d.end());
 
-    // For scaled_to_grid, viscosity/diffusivity coefficients are vertically homogeneous and
-    // time-invariant. For AMReX plotfiles, write them to a dedicated coefficient plotfile and
-    // omit them from regular time-series plotfiles. For AMR, we write a coefficient plotfile
-    // per plot output so it matches the current grid hierarchy.
-    Vector<std::string> varnames_2d_coeff;
-    const bool write_coeff_plotfile =
-        (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) &&
-        (plotfile_type == PlotfileType::amrex);
-
-    if (write_coeff_plotfile) {
-        for (auto const& nm : varnames_2d) {
-            if (nm == "visc2") {
-                varnames_2d_coeff.push_back(nm);
-                continue;
-            }
-            for (int n = 0; n < NCONS; ++n) {
-                if (nm == std::string("diff2_") + cons_names[n]) {
-                    varnames_2d_coeff.push_back(nm);
-                    break;
-                }
-            }
-        }
-
-        varnames_2d.erase(std::remove_if(varnames_2d.begin(), varnames_2d.end(),
-                                         [&] (std::string const& nm) {
-                                             if (nm == "visc2") { return true; }
-                                             for (int n = 0; n < NCONS; ++n) {
-                                                 if (nm == std::string("diff2_") + cons_names[n]) { return true; }
-                                             }
-                                             return false;
-                                         }),
-                          varnames_2d.end());
-    }
-
     Vector<std::string> varnames_2d_rho;
     Vector<std::string> varnames_2d_u;
     Vector<std::string> varnames_2d_v;
@@ -95,8 +61,6 @@ REMORA::WritePlotFile (int istep_for_plot)
         FillPatchNoBC(lev, t_new[lev], *xvel_new[lev], xvel_new, BdyVars::u,0,true,false);
         FillPatchNoBC(lev, t_new[lev], *yvel_new[lev], yvel_new, BdyVars::v,0,true,false);
         FillPatchNoBC(lev, t_new[lev], *zvel_new[lev], zvel_new, BdyVars::null,0,true,false);
-        // These are constant-in-time fields for most runs, but we still ensure
-        // ghost cells are valid before writing plotfiles.
         FillPatchNoBC(lev, t_new[lev], *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r), BdyVars::null,0,true,false);
         FillPatchNoBC(lev, t_new[lev], *vec_diff2[lev],   GetVecOfPtrs(vec_diff2),   BdyVars::null,0,true,false);
     }
@@ -128,53 +92,6 @@ REMORA::WritePlotFile (int istep_for_plot)
           mf_2d_v[lev].define(ba2d, dmap[lev], ncomp_mf_2d_v  , IntVect(0,0,0));
     }
 
-    // Coefficient plotfile (2D rho-point fields).
-    //
-    // NOTE: REMORA/AMReX is built in 3D (AMREX_SPACEDIM=3). For coefficient output we write a
-    // k=0 slab (nz=1) so downstream tools see these fields as 2D (or 3D with a singleton z).
-    const int ncomp_mf_2d_rho_coeff = static_cast<int>(varnames_2d_coeff.size());
-    Vector<MultiFab> plotMF_zero;
-    Vector<MultiFab> mf_2d_rho_coeff;
-    Vector<MultiFab> mf_2d_u_zero;
-    Vector<MultiFab> mf_2d_v_zero;
-    Vector<MultiFab> mf_nd_coeff;
-    Vector<Geometry> geom_coeff;
-    if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-        plotMF_zero.resize(finest_level+1);
-        mf_2d_rho_coeff.resize(finest_level+1);
-        mf_2d_u_zero.resize(finest_level+1);
-        mf_2d_v_zero.resize(finest_level+1);
-        mf_nd_coeff.resize(finest_level+1);
-        geom_coeff.resize(finest_level+1);
-        for (int lev = 0; lev <= finest_level; ++lev) {
-            // Build a k=0 slab BoxArray for 2D coefficient output.
-            BoxArray ba(grids[lev]);
-            BoxList bl2d = ba.boxList();
-            for (auto& b : bl2d) { b.setRange(2,0); }
-            BoxArray ba2d(std::move(bl2d));
-
-            // "3D" plot MF with zero components, defined on the slab BoxArray so the plotfile
-            // header describes a 2D (nz=1) hierarchy.
-            plotMF_zero[lev].define(ba2d, dmap[lev], 0, IntVect(0,0,0));
-
-            mf_2d_rho_coeff[lev].define(ba2d, dmap[lev], ncomp_mf_2d_rho_coeff, IntVect(0,0,0));
-            mf_2d_u_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
-            mf_2d_v_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
-
-            // Nodal coordinates for the coefficient plotfile, also on the slab hierarchy.
-            BoxArray nodal_grids(ba2d);
-            nodal_grids.surroundingNodes();
-            mf_nd_coeff[lev].define(nodal_grids, dmap[lev], AMREX_SPACEDIM, 0);
-            mf_nd_coeff[lev].setVal(0.0_rt);
-
-            // Geometry for the coefficient plotfile: use a z-slab domain (nz=1).
-            Box dom2d = Geom()[lev].Domain();
-            dom2d.setRange(2,0);
-            Array<int,AMREX_SPACEDIM> periodicity =
-                {Geom()[lev].isPeriodic(0),Geom()[lev].isPeriodic(1),Geom()[lev].isPeriodic(2)};
-            geom_coeff[lev].define(dom2d, &(Geom()[lev].ProbDomain()), Geom()[lev].Coord(), periodicity.data());
-        }
-    }
 
     // Array of MultiFabs for nodal data
     Vector<MultiFab> mf_nd(finest_level+1);
@@ -344,72 +261,6 @@ REMORA::WritePlotFile (int istep_for_plot)
          }
     }
 
-    // Fill the time-invariant coefficient plotfile (2D rho points) if enabled
-    if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-        int icomp_coeff = 0;
-        for (auto const& nm : varnames_2d_coeff) {
-            if (nm == "visc2") {
-                for (int lev = 0; lev <= finest_level; ++lev) {
-                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                        const Box& bx = mfi.validbox();
-                        const int K = mfi.index();
-                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
-                        auto src = vec_visc2_r[lev]->const_array(K);
-                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            dst(i,j,k) = src(i,j,0,0);
-                        });
-                    }
-                }
-                icomp_coeff++;
-                continue;
-            }
-            if (nm == "diff2_temp") {
-                for (int lev = 0; lev <= finest_level; ++lev) {
-                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                        const Box& bx = mfi.validbox();
-                        const int K = mfi.index();
-                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
-                        auto src = vec_diff2[lev]->const_array(K);
-                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            dst(i,j,k) = src(i,j,0,Temp_comp);
-                        });
-                    }
-                }
-                icomp_coeff++;
-                continue;
-            }
-            if (nm == "diff2_salt") {
-                for (int lev = 0; lev <= finest_level; ++lev) {
-                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                        const Box& bx = mfi.validbox();
-                        const int K = mfi.index();
-                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
-                        auto src = vec_diff2[lev]->const_array(K);
-                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            dst(i,j,k) = src(i,j,0,Salt_comp);
-                        });
-                    }
-                }
-                icomp_coeff++;
-                continue;
-            }
-            if (nm == "diff2_tracer") {
-                for (int lev = 0; lev <= finest_level; ++lev) {
-                    for (MFIter mfi(mf_2d_rho_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                        const Box& bx = mfi.validbox();
-                        const int K = mfi.index();
-                        auto dst = mf_2d_rho_coeff[lev].array(mfi, icomp_coeff);
-                        auto src = vec_diff2[lev]->const_array(K);
-                        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            dst(i,j,k) = src(i,j,0,Tracer_comp);
-                        });
-                    }
-                }
-                icomp_coeff++;
-                continue;
-            }
-        }
-    }
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
@@ -553,18 +404,6 @@ REMORA::WritePlotFile (int istep_for_plot)
             });
         } // mfi
 
-        // Fill the coefficient plotfile nodal z coordinate (k=0 slab) if enabled.
-        if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-            for (MFIter mfi(mf_nd_coeff[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-                const Box& bx = mfi.tilebox();
-                Array4<Real> mf_arr = mf_nd_coeff[lev].array(mfi);
-                Array4<Real const> zp_arr = vec_z_phys_nd[lev]->const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    mf_arr(i,j,k,2) = zp_arr(i,j,k) + (N-k) * dz;
-                });
-            }
-        }
 
     } // lev
 
@@ -576,28 +415,7 @@ REMORA::WritePlotFile (int istep_for_plot)
 
     if (finest_level == 0)
     {
-        if (plotfile_type == PlotfileType::amrex) {
-            if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-                const std::string coeff_plotfilename = plotfilename + "_hmixcoef";
-                amrex::Print() << "Writing horizontal mixing coefficient plotfile "
-                               << coeff_plotfilename << "\n";
-                Vector<std::string> empty_3d;
-                Vector<std::string> empty_2d;
-                WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                      GetVecOfConstPtrs(plotMF_zero),
-                                                      GetVecOfConstPtrs(mf_nd_coeff),
-                                                      GetVecOfConstPtrs(mf_u),
-                                                      GetVecOfConstPtrs(mf_v),
-                                                      GetVecOfConstPtrs(mf_w),
-                                                      GetVecOfConstPtrs(mf_2d_rho_coeff),
-                                                      GetVecOfConstPtrs(mf_2d_u_zero),
-                                                      GetVecOfConstPtrs(mf_2d_v_zero),
-                                                      empty_3d,
-                                                      varnames_2d_coeff, empty_2d, empty_2d,
-                                                      geom_coeff,
-                                                      t_new[0], istep, refRatio());
-                writeJobInfo(coeff_plotfilename);
-            }
+            if (plotfile_type == PlotfileType::amrex) {
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             WriteMultiLevelPlotfileWithBathymetry(plotfilename, finest_level+1,
                                                   GetVecOfConstPtrs(plotMF),
@@ -629,28 +447,7 @@ REMORA::WritePlotFile (int istep_for_plot)
         }
 
     } else { // multilevel
-        if (plotfile_type == PlotfileType::amrex) {
-            if (write_coeff_plotfile && (ncomp_mf_2d_rho_coeff > 0)) {
-                const std::string coeff_plotfilename = plotfilename + "_hmixcoef";
-                amrex::Print() << "Writing horizontal mixing coefficient plotfile "
-                               << coeff_plotfilename << "\n";
-                Vector<std::string> empty_3d;
-                Vector<std::string> empty_2d;
-                WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
-                                                      GetVecOfConstPtrs(plotMF_zero),
-                                                      GetVecOfConstPtrs(mf_nd_coeff),
-                                                      GetVecOfConstPtrs(mf_u),
-                                                      GetVecOfConstPtrs(mf_v),
-                                                      GetVecOfConstPtrs(mf_w),
-                                                      GetVecOfConstPtrs(mf_2d_rho_coeff),
-                                                      GetVecOfConstPtrs(mf_2d_u_zero),
-                                                      GetVecOfConstPtrs(mf_2d_v_zero),
-                                                      empty_3d,
-                                                      varnames_2d_coeff, empty_2d, empty_2d,
-                                                      geom_coeff,
-                                                      t_new[0], istep, ref_ratio);
-                writeJobInfo(coeff_plotfilename);
-            }
+            if (plotfile_type == PlotfileType::amrex) {
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             int lev0 = 0;
             [[maybe_unused]] int desired_ratio = std::max(std::max(ref_ratio[lev0][0],ref_ratio[lev0][1]),ref_ratio[lev0][2]);
@@ -1144,12 +941,15 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where)
                 salt(i,j,k) = fill_value;
             }
         });
-        ParallelFor(gbx_coeff, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        // visc2/diff2 are stored as horizontally-varying only (nz==1).
+        // Only touch the k==0 slab here to avoid out-of-bounds writes when
+        // these MultiFabs have a single vertical layer.
+        ParallelFor(makeSlab(gbx_coeff,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int )
         {
             if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0
-                visc2(i,j,k) = fill_value;
+                visc2(i,j,0) = fill_value;
                 for (int n = 0; n < NCONS; ++n) {
-                    diff2(i,j,k,n) = fill_value;
+                    diff2(i,j,0,n) = fill_value;
                 }
             }
         });

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -21,6 +21,38 @@ REMORA::WritePlotFile (int istep_for_plot)
     Vector<std::string> varnames_3d;
     varnames_3d.insert(varnames_3d.end(), plot_var_names_3d.begin(), plot_var_names_3d.end());
 
+    // For scaled_to_grid, horizontal mixing coefficients are time-invariant. For AMReX plotfiles,
+    // write them once to a dedicated static plotfile and omit them from regular time-series plotfiles.
+    Vector<std::string> varnames_3d_coeff;
+    const bool write_static_coeff_plotfile =
+        (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) &&
+        (plotfile_type == PlotfileType::amrex);
+
+    if (write_static_coeff_plotfile) {
+        for (auto const& nm : varnames_3d) {
+            if (nm == "visc2") {
+                varnames_3d_coeff.push_back(nm);
+                continue;
+            }
+            for (int n = 0; n < NCONS; ++n) {
+                if (nm == std::string("diff2_") + cons_names[n]) {
+                    varnames_3d_coeff.push_back(nm);
+                    break;
+                }
+            }
+        }
+
+        varnames_3d.erase(std::remove_if(varnames_3d.begin(), varnames_3d.end(),
+                                         [&] (std::string const& nm) {
+                                             if (nm == "visc2") { return true; }
+                                             for (int n = 0; n < NCONS; ++n) {
+                                                 if (nm == std::string("diff2_") + cons_names[n]) { return true; }
+                                             }
+                                             return false;
+                                         }),
+                          varnames_3d.end());
+    }
+
     Vector<std::string> varnames_2d;
     varnames_2d.insert(varnames_2d.end(), plot_var_names_2d.begin(), plot_var_names_2d.end());
 
@@ -29,6 +61,7 @@ REMORA::WritePlotFile (int istep_for_plot)
     Vector<std::string> varnames_2d_v;
 
     const int ncomp_mf_3d = varnames_3d.size();
+    const int ncomp_mf_3d_coeff = varnames_3d_coeff.size();
     const auto ngrow_vars = IntVect(NGROW-1,NGROW-1,0);
 
     // These are the ncomp for the 2D cell-centered, x-face-based, y-face-based MultiFabs respectively
@@ -57,6 +90,10 @@ REMORA::WritePlotFile (int istep_for_plot)
         FillPatchNoBC(lev, t_new[lev], *xvel_new[lev], xvel_new, BdyVars::u,0,true,false);
         FillPatchNoBC(lev, t_new[lev], *yvel_new[lev], yvel_new, BdyVars::v,0,true,false);
         FillPatchNoBC(lev, t_new[lev], *zvel_new[lev], zvel_new, BdyVars::null,0,true,false);
+        // These are constant-in-time fields for most runs, but we still ensure
+        // ghost cells are valid before writing plotfiles.
+        FillPatchNoBC(lev, t_new[lev], *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r), BdyVars::null,0,true,false);
+        FillPatchNoBC(lev, t_new[lev], *vec_diff2[lev],   GetVecOfPtrs(vec_diff2),   BdyVars::null,0,true,false);
     }
 
     Real fill_value = 0.0_rt;
@@ -69,6 +106,16 @@ REMORA::WritePlotFile (int istep_for_plot)
     for (int lev = 0; lev <= finest_level; ++lev) {
         plotMF[lev].define(grids[lev], dmap[lev], ncomp_mf_3d, ngrow_vars);
         plotMF[lev].setVal(1.234e20);
+    }
+
+    // 3D MultiFabs to hold time-invariant coefficient fields (written once)
+    Vector<MultiFab> plotMF_coeff;
+    if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+        plotMF_coeff.resize(finest_level+1);
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            plotMF_coeff[lev].define(grids[lev], dmap[lev], ncomp_mf_3d_coeff, ngrow_vars);
+            plotMF_coeff[lev].setVal(1.234e20);
+        }
     }
 
     // Array of 2D MultiFabs to hold the plotfile data
@@ -85,6 +132,25 @@ REMORA::WritePlotFile (int istep_for_plot)
         mf_2d_rho[lev].define(ba2d, dmap[lev], ncomp_mf_2d_rho, IntVect(0,0,0));
           mf_2d_u[lev].define(ba2d, dmap[lev], ncomp_mf_2d_u  , IntVect(0,0,0));
           mf_2d_v[lev].define(ba2d, dmap[lev], ncomp_mf_2d_v  , IntVect(0,0,0));
+    }
+
+    // Empty 2D MultiFabs for the static coefficient plotfile
+    Vector<MultiFab> mf_2d_rho_zero;
+    Vector<MultiFab> mf_2d_u_zero;
+    Vector<MultiFab> mf_2d_v_zero;
+    if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+        mf_2d_rho_zero.resize(finest_level+1);
+        mf_2d_u_zero.resize(finest_level+1);
+        mf_2d_v_zero.resize(finest_level+1);
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            BoxArray ba(grids[lev]);
+            BoxList bl2d = ba.boxList();
+            for (auto& b : bl2d) { b.setRange(2,0); }
+            BoxArray ba2d(std::move(bl2d));
+            mf_2d_rho_zero[lev].define(ba2d, dmap[lev], 0, IntVect(0,0,0));
+            mf_2d_u_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
+            mf_2d_v_zero[lev].define  (ba2d, dmap[lev], 0, IntVect(0,0,0));
+        }
     }
 
     // Array of MultiFabs for nodal data
@@ -295,6 +361,42 @@ REMORA::WritePlotFile (int istep_for_plot)
             mf_comp += AMREX_SPACEDIM;
         } // if containerHasElement
 
+        // Horizontal mixing coefficients (rho points) written into the time-series plotfile
+        if (containerHasElement(varnames_3d, "visc2")) {
+            if (vec_visc2_r[lev]->contains_nan(0, 1, 0, true) || vec_visc2_r[lev]->contains_inf(0, 1, 0, true)) {
+                amrex::Abort("Found while writing output: visc2 contains nan or inf");
+            }
+            MultiFab::Copy(plotMF[lev], *vec_visc2_r[lev], 0, mf_comp, 1, ngrow_vars);
+            mf_comp += 1;
+        }
+
+        for (int n = 0; n < NCONS; ++n) {
+            const std::string nm = std::string("diff2_") + cons_names[n];
+            if (containerHasElement(varnames_3d, nm)) {
+                if (vec_diff2[lev]->contains_nan(n, 1, 0, true) || vec_diff2[lev]->contains_inf(n, 1, 0, true)) {
+                    amrex::Abort("Found while writing output: diff2 contains nan or inf");
+                }
+                MultiFab::Copy(plotMF[lev], *vec_diff2[lev], n, mf_comp, 1, ngrow_vars);
+                mf_comp += 1;
+            }
+        }
+
+        // Time-invariant coefficient plotfile for scaled_to_grid
+        if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+            int cf_comp = 0;
+            if (containerHasElement(varnames_3d_coeff, "visc2")) {
+                MultiFab::Copy(plotMF_coeff[lev], *vec_visc2_r[lev], 0, cf_comp, 1, ngrow_vars);
+                cf_comp += 1;
+            }
+            for (int n = 0; n < NCONS; ++n) {
+                const std::string nm = std::string("diff2_") + cons_names[n];
+                if (containerHasElement(varnames_3d_coeff, nm)) {
+                    MultiFab::Copy(plotMF_coeff[lev], *vec_diff2[lev], n, cf_comp, 1, ngrow_vars);
+                    cf_comp += 1;
+                }
+            }
+        }
+
 #ifdef REMORA_USE_PARTICLES
         const auto& particles_namelist( particleData.getNames() );
         for (ParticlesNamesVector::size_type i = 0; i < particles_namelist.size(); i++) {
@@ -349,6 +451,30 @@ REMORA::WritePlotFile (int istep_for_plot)
     if (finest_level == 0)
     {
         if (plotfile_type == PlotfileType::amrex) {
+            if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+                const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
+                if (!amrex::FileExists(coeff_plotfilename)) {
+                    amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
+                                   << coeff_plotfilename << "\n";
+                    Vector<int> level_steps_zero = istep;
+                    for (auto& s : level_steps_zero) { s = 0; }
+                    Vector<std::string> empty_2d;
+                    WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
+                                                          GetVecOfConstPtrs(plotMF_coeff),
+                                                          GetVecOfConstPtrs(mf_nd),
+                                                          GetVecOfConstPtrs(mf_u),
+                                                          GetVecOfConstPtrs(mf_v),
+                                                          GetVecOfConstPtrs(mf_w),
+                                                          GetVecOfConstPtrs(mf_2d_rho_zero),
+                                                          GetVecOfConstPtrs(mf_2d_u_zero),
+                                                          GetVecOfConstPtrs(mf_2d_v_zero),
+                                                          varnames_3d_coeff,
+                                                          empty_2d, empty_2d, empty_2d,
+                                                          Geom(),
+                                                          0.0_rt, level_steps_zero, refRatio());
+                    writeJobInfo(coeff_plotfilename);
+                }
+            }
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             WriteMultiLevelPlotfileWithBathymetry(plotfilename, finest_level+1,
                                                   GetVecOfConstPtrs(plotMF),
@@ -381,6 +507,30 @@ REMORA::WritePlotFile (int istep_for_plot)
 
     } else { // multilevel
         if (plotfile_type == PlotfileType::amrex) {
+            if (write_static_coeff_plotfile && (ncomp_mf_3d_coeff > 0)) {
+                const std::string coeff_plotfilename = plot_file_name + "_hmixcoef";
+                if (!amrex::FileExists(coeff_plotfilename)) {
+                    amrex::Print() << "Writing static horizontal mixing coefficient plotfile "
+                                   << coeff_plotfilename << "\n";
+                    Vector<int> level_steps_zero = istep;
+                    for (auto& s : level_steps_zero) { s = 0; }
+                    Vector<std::string> empty_2d;
+                    WriteMultiLevelPlotfileWithBathymetry(coeff_plotfilename, finest_level+1,
+                                                          GetVecOfConstPtrs(plotMF_coeff),
+                                                          GetVecOfConstPtrs(mf_nd),
+                                                          GetVecOfConstPtrs(mf_u),
+                                                          GetVecOfConstPtrs(mf_v),
+                                                          GetVecOfConstPtrs(mf_w),
+                                                          GetVecOfConstPtrs(mf_2d_rho_zero),
+                                                          GetVecOfConstPtrs(mf_2d_u_zero),
+                                                          GetVecOfConstPtrs(mf_2d_v_zero),
+                                                          varnames_3d_coeff,
+                                                          empty_2d, empty_2d, empty_2d,
+                                                          Geom(),
+                                                          0.0_rt, level_steps_zero, ref_ratio);
+                    writeJobInfo(coeff_plotfilename);
+                }
+            }
             amrex::Print() << "Writing plotfile " << plotfilename << "\n";
             int lev0 = 0;
             [[maybe_unused]] int desired_ratio = std::max(std::max(ref_ratio[lev0][0],ref_ratio[lev0][1]),ref_ratio[lev0][2]);
@@ -843,6 +993,7 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where)
 {
     for (MFIter mfi(*cons_new[lev],false); mfi.isValid(); ++mfi) {
         Box gbx1 = mfi.growntilebox(IntVect(NGROW+1,NGROW+1,0));
+        Box gbx_coeff = mfi.growntilebox(IntVect(NGROW,NGROW,0));
         Box ubx = mfi.grownnodaltilebox(0,IntVect(NGROW,NGROW,0));
         Box vbx = mfi.grownnodaltilebox(1,IntVect(NGROW,NGROW,0));
 
@@ -851,6 +1002,8 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where)
         Array4<Real> const& vbar = vec_vbar[lev]->array(mfi);
         Array4<Real> const& xvel = xvel_new[lev]->array(mfi);
         Array4<Real> const& yvel = yvel_new[lev]->array(mfi);
+        Array4<Real> const& visc2 = vec_visc2_r[lev]->array(mfi);
+        Array4<Real> const& diff2 = vec_diff2[lev]->array(mfi);
         Array4<Real> const& temp = cons_new[lev]->array(mfi,Temp_comp);
         Array4<Real> const& salt = cons_new[lev]->array(mfi,Salt_comp);
 
@@ -869,6 +1022,15 @@ REMORA::mask_arrays_for_write(int lev, Real fill_value, Real fill_where)
             if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0
                 temp(i,j,k) = fill_value;
                 salt(i,j,k) = fill_value;
+            }
+        });
+        ParallelFor(gbx_coeff, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            if (mskr(i,j,0) == 0.0) {  // Explicitly compare to 0.0
+                visc2(i,j,k) = fill_value;
+                for (int n = 0; n < NCONS; ++n) {
+                    diff2(i,j,k,n) = fill_value;
+                }
             }
         });
         ParallelFor(makeSlab(ubx,2,0), 3, [=] AMREX_GPU_DEVICE (int i, int j, int , int n)

--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -174,9 +174,9 @@ REMORA::WritePlotFile (int istep_for_plot)
                      const int K = mfi.index();
                      auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
                      auto src = vec_visc2_r[lev]->const_array(K);
-                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                         dst(i,j,k) = src(i,j,0,0);
-                     });
+                     ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept {
+                        dst(i,j,0) = src(i,j,0);
+                    });
                  }
              }
              icomp_rho++;
@@ -188,8 +188,8 @@ REMORA::WritePlotFile (int istep_for_plot)
                      const int K = mfi.index();
                      auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
                      auto src = vec_diff2[lev]->const_array(K);
-                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                         dst(i,j,k) = src(i,j,0,Temp_comp);
+                     ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept {
+                         dst(i,j,0) = src(i,j,0,Temp_comp);
                      });
                  }
              }
@@ -202,8 +202,8 @@ REMORA::WritePlotFile (int istep_for_plot)
                      const int K = mfi.index();
                      auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
                      auto src = vec_diff2[lev]->const_array(K);
-                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                         dst(i,j,k) = src(i,j,0,Salt_comp);
+                     ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept {
+                         dst(i,j,0) = src(i,j,0,Salt_comp);
                      });
                  }
              }
@@ -216,8 +216,8 @@ REMORA::WritePlotFile (int istep_for_plot)
                      const int K = mfi.index();
                      auto dst = mf_2d_rho[lev].array(mfi, icomp_rho);
                      auto src = vec_diff2[lev]->const_array(K);
-                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                         dst(i,j,k) = src(i,j,0,Tracer_comp);
+                     ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept {
+                         dst(i,j,0) = src(i,j,0,Tracer_comp);
                      });
                  }
              }

--- a/Source/IO/REMORA_SetPlotVars.cpp
+++ b/Source/IO/REMORA_SetPlotVars.cpp
@@ -44,6 +44,20 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
         plot_var_names_3d.clear();
     }
 
+    // If horizontal mixing is scaled to grid size, automatically output the
+    // spatially-varying coefficients used by the run.
+    if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+        if (!containerHasElement(plot_var_names_3d, "visc2")) {
+            plot_var_names_3d.push_back("visc2");
+        }
+        for (int n = 0; n < NCONS; ++n) {
+            const std::string nm = std::string("diff2_") + cons_names[n];
+            if (!containerHasElement(plot_var_names_3d, nm)) {
+                plot_var_names_3d.push_back(nm);
+            }
+        }
+    }
+
     // Get state variables in the same order as we define them,
     // since they may be in any order in the input list
     Vector<std::string> tmp_plot_names;
@@ -77,6 +91,17 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
                tmp_plot_names.push_back(derived_names[i]);
         } // if
     } // i
+
+    // Horizontal mixing coefficients (cell-centered rho points)
+    if (containerHasElement(plot_var_names_3d, "visc2")) {
+        tmp_plot_names.push_back("visc2");
+    }
+    for (int n = 0; n < NCONS; ++n) {
+        const std::string nm = std::string("diff2_") + cons_names[n];
+        if (containerHasElement(plot_var_names_3d, nm)) {
+            tmp_plot_names.push_back(nm);
+        }
+    }
 
 #ifdef REMORA_USE_PARTICLES
     const auto& particles_namelist( particleData.getNamesUnalloc() );
@@ -200,6 +225,19 @@ REMORA::append3DPlotVariables (const std::string& pp_plot_var_names_3d)
             pp.get(pp_plot_var_names_3d.c_str(), nm, i);
             // Add the named variable to our list of plot variables
             // if it is not already in the list
+            if (!containerHasElement(plot_var_names_3d, nm)) {
+                plot_var_names_3d.push_back(nm);
+            }
+        }
+    }
+
+    // Same auto-append for scaled_to_grid as in set3DPlotVariables.
+    if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+        if (!containerHasElement(plot_var_names_3d, "visc2")) {
+            plot_var_names_3d.push_back("visc2");
+        }
+        for (int n = 0; n < NCONS; ++n) {
+            const std::string nm = std::string("diff2_") + cons_names[n];
             if (!containerHasElement(plot_var_names_3d, nm)) {
                 plot_var_names_3d.push_back(nm);
             }

--- a/Source/IO/REMORA_SetPlotVars.cpp
+++ b/Source/IO/REMORA_SetPlotVars.cpp
@@ -44,18 +44,6 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
         plot_var_names_3d.clear();
     }
 
-    // Horizontal mixing coefficients are vertically homogeneous, so we output
-    // them as 2D rho-point fields (see set2DPlotVariables).
-    if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-        plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), "visc2"),
-                                plot_var_names_3d.end());
-        for (int n = 0; n < NCONS; ++n) {
-            const std::string nm = std::string("diff2_") + cons_names[n];
-            plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), nm),
-                                    plot_var_names_3d.end());
-        }
-    }
-
     // Get state variables in the same order as we define them,
     // since they may be in any order in the input list
     Vector<std::string> tmp_plot_names;
@@ -240,17 +228,6 @@ REMORA::append3DPlotVariables (const std::string& pp_plot_var_names_3d)
             if (!containerHasElement(plot_var_names_3d, nm)) {
                 plot_var_names_3d.push_back(nm);
             }
-        }
-    }
-
-    // Coefficient fields are 2D (see append2DPlotVariables / set2DPlotVariables).
-    if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-        plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), "visc2"),
-                                plot_var_names_3d.end());
-        for (int n = 0; n < NCONS; ++n) {
-            const std::string nm = std::string("diff2_") + cons_names[n];
-            plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), nm),
-                                    plot_var_names_3d.end());
         }
     }
 

--- a/Source/IO/REMORA_SetPlotVars.cpp
+++ b/Source/IO/REMORA_SetPlotVars.cpp
@@ -44,17 +44,15 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
         plot_var_names_3d.clear();
     }
 
-    // If horizontal mixing is scaled to grid size, automatically output the
-    // spatially-varying coefficients used by the run.
+    // Horizontal mixing coefficients are vertically homogeneous, so we output
+    // them as 2D rho-point fields (see set2DPlotVariables).
     if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-        if (!containerHasElement(plot_var_names_3d, "visc2")) {
-            plot_var_names_3d.push_back("visc2");
-        }
+        plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), "visc2"),
+                                plot_var_names_3d.end());
         for (int n = 0; n < NCONS; ++n) {
             const std::string nm = std::string("diff2_") + cons_names[n];
-            if (!containerHasElement(plot_var_names_3d, nm)) {
-                plot_var_names_3d.push_back(nm);
-            }
+            plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), nm),
+                                    plot_var_names_3d.end());
         }
     }
 
@@ -91,17 +89,6 @@ REMORA::set3DPlotVariables (const std::string& pp_plot_var_names_3d)
                tmp_plot_names.push_back(derived_names[i]);
         } // if
     } // i
-
-    // Horizontal mixing coefficients (cell-centered rho points)
-    if (containerHasElement(plot_var_names_3d, "visc2")) {
-        tmp_plot_names.push_back("visc2");
-    }
-    for (int n = 0; n < NCONS; ++n) {
-        const std::string nm = std::string("diff2_") + cons_names[n];
-        if (containerHasElement(plot_var_names_3d, nm)) {
-            tmp_plot_names.push_back(nm);
-        }
-    }
 
 #ifdef REMORA_USE_PARTICLES
     const auto& particles_namelist( particleData.getNamesUnalloc() );
@@ -153,6 +140,20 @@ REMORA::set2DPlotVariables (const std::string& pp_plot_var_names_2d)
         plot_var_names_2d.clear();
     }
 
+    // If horizontal mixing is scaled_to_grid, automatically output the spatially
+    // varying coefficients used by the run as 2D fields.
+    if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+        if (!containerHasElement(plot_var_names_2d, "visc2")) {
+            plot_var_names_2d.push_back("visc2");
+        }
+        for (int n = 0; n < NCONS; ++n) {
+            const std::string nm = std::string("diff2_") + cons_names[n];
+            if (!containerHasElement(plot_var_names_2d, nm)) {
+                plot_var_names_2d.push_back(nm);
+            }
+        }
+    }
+
     // Get state variables in the same order as we define them,
     // since they may be in any order in the input list
     Vector<std::string> tmp_plot_names;
@@ -186,6 +187,17 @@ REMORA::set2DPlotVariables (const std::string& pp_plot_var_names_2d)
                tmp_plot_names.push_back(derived_names[i]);
         } // if
     } // i
+
+    // Horizontal mixing coefficients (2D rho points)
+    if (containerHasElement(plot_var_names_2d, "visc2")) {
+        tmp_plot_names.push_back("visc2");
+    }
+    for (int n = 0; n < NCONS; ++n) {
+        const std::string nm = std::string("diff2_") + cons_names[n];
+        if (containerHasElement(plot_var_names_2d, nm)) {
+            tmp_plot_names.push_back(nm);
+        }
+    }
 
 #ifdef REMORA_USE_PARTICLES
     const auto& particles_namelist( particleData.getNamesUnalloc() );
@@ -231,16 +243,14 @@ REMORA::append3DPlotVariables (const std::string& pp_plot_var_names_3d)
         }
     }
 
-    // Same auto-append for scaled_to_grid as in set3DPlotVariables.
+    // Coefficient fields are 2D (see append2DPlotVariables / set2DPlotVariables).
     if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
-        if (!containerHasElement(plot_var_names_3d, "visc2")) {
-            plot_var_names_3d.push_back("visc2");
-        }
+        plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), "visc2"),
+                                plot_var_names_3d.end());
         for (int n = 0; n < NCONS; ++n) {
             const std::string nm = std::string("diff2_") + cons_names[n];
-            if (!containerHasElement(plot_var_names_3d, nm)) {
-                plot_var_names_3d.push_back(nm);
-            }
+            plot_var_names_3d.erase(std::remove(plot_var_names_3d.begin(), plot_var_names_3d.end(), nm),
+                                    plot_var_names_3d.end());
         }
     }
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -644,26 +644,200 @@ REMORA::set_analytic_vmix(int lev) {
  * @param[in   ] lev    level to operate on
  */
 void
+REMORA::set_masks(int lev)
+{
+    if (solverChoice.mask_type == MaskType::analytic) {
+        prob->init_analytic_masks(lev,geom[lev], solverChoice, *this, *vec_mskr[lev]);
+        calculate_nodal_masks(lev);
+    } else if (solverChoice.mask_type == MaskType::netcdf) {
+#ifdef REMORA_USE_NETCDF
+        if (lev == 0) {
+            amrex::Print() << "Calling init_masks_from_netcdf level " << lev << std::endl;
+            init_masks_from_netcdf(lev);
+            amrex::Print() << "Masks loaded from netcdf file \n " << std::endl;
+        } else {
+            Real dummy_time = 0.0_rt;
+            FillCoarsePatchPC(lev, dummy_time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
+                    BCVars::foextrap_bc);
+            calculate_nodal_masks(lev);
+        }
+#endif
+    }
+    fill_3d_masks(lev);
+}
+
+/**
+ * @param[in   ] lev    level to operate on
+ */
+void
 REMORA::set_hmixcoef(int lev)
 {
     BL_PROFILE("REMORA::set_hmixcoef()");
+
     if (solverChoice.horiz_mixing_type == HorizMixingType::analytic) {
-        prob->init_analytic_hmix(lev, geom[lev], solverChoice, *this, *vec_visc2_p[lev], *vec_visc2_r[lev], *vec_diff2[lev]);
+        prob->init_analytic_hmix(lev, geom[lev], solverChoice,
+                                 *this, *vec_visc2_p[lev], *vec_visc2_r[lev], *vec_diff2[lev]);
+
     } else if (solverChoice.horiz_mixing_type == HorizMixingType::constant) {
         vec_visc2_p[lev]->setVal(solverChoice.visc2);
         vec_visc2_r[lev]->setVal(solverChoice.visc2);
-        for (int n=0; n<NCONS; n++) {
-            vec_diff2[lev]->setVal(solverChoice.tnu2[n],n,1);
+        for (int n=0; n<NCONS; n++)
+            vec_diff2[lev]->setVal(solverChoice.tnu2[n], n, 1);
+
+    // Scale harmonic viscosity and diffusivity by the grid size as ROMS
+    // does in Utility/ini_hmixcoef.F. Intended for curvilinear grids.
+    //
+    // Define the ROMS grid factor (grdscl):
+    //     G(i,j) = sqrt( 1 / (pm(i,j) * pn(i,j)) )
+    //            = sqrt(cell area)
+    //     Gmax   = max over grid of G(i,j)
+    //
+    // Then horizontal harmonic mixing coefficients are scaled as:
+    //     nu(i,j)       = nu0    * G(i,j) / Gmax
+    //     kappa_n(i,j)  = kappa0 * G(i,j) / Gmax
+    //
+    // where:
+    //     nu0     = solverChoice.visc2
+    //     kappa0  = solverChoice.tnu2[n]
+    //
+    // This makes mixing strongest where grid spacing is largest,
+    // and ensures the maximum coefficient equals the user-specified value.
+    // The normalization (Gmax) is computed over the entire grid (ignoring masks).
+
+    } else if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
+
+        // ------------------------------------------------------------
+        // Step 1: Compute grdmax over entire grid
+        // ------------------------------------------------------------
+        vec_visc2_r[lev]->setVal(solverChoice.visc2);
+        vec_visc2_p[lev]->setVal(solverChoice.visc2);
+        vec_diff2[lev]->setVal(solverChoice.visc2);
+
+        // NOTE: This must be GPU-safe. Do not dereference MultiFab data on host.
+        // Force the reduction to run in the GPU launch region if GPUs are enabled.
+        // (If the launch region is disabled at runtime, ReduceMax may fall back to
+        // a host path that can try to read device-only data.)
+        amrex::Gpu::LaunchSafeGuard lsg(true);
+        Real denom_min = amrex::ReduceMin(*vec_pm[lev], *vec_pn[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& pm,
+                                      Array4<Real const> const& pn) -> Real
+            {
+                Real local_min = 1.0e200_rt;
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    local_min = amrex::min(local_min, pm(i,j,0) * pn(i,j,0));
+                });
+                return local_min;
+            });
+
+        ParallelDescriptor::ReduceRealMin(denom_min);
+        if (denom_min <= 0.0_rt) {
+            Abort("scaled_to_grid: found non-positive pm*pn (grid metrics must be > 0)");
         }
+
+        Real grdmax = amrex::ReduceMax(*vec_pm[lev], *vec_pn[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& pm,
+                                      Array4<Real const> const& pn) -> Real
+            {
+                Real local_max = 0.0_rt;
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    Real denom = pm(i,j,0) * pn(i,j,0);
+                    if (denom > 0.0_rt) {
+                        Real G = std::sqrt(1.0_rt / denom);
+                        local_max = amrex::max(local_max, G);
+                    }
+                });
+                return local_max;
+            });
+
+        ParallelDescriptor::ReduceRealMax(grdmax);
+        if (grdmax <= 0.0_rt)
+            Abort("scaled_to_grid: grdmax <= 0");
+
+        Real visc0 = solverChoice.visc2;
+        Real cff   = visc0 / grdmax;
+
+        // ------------------------------------------------------------
+        // Step 2: Set rho coefficients everywhere
+        // ------------------------------------------------------------
+        for (MFIter mfi(*vec_visc2_r[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.validbox();
+            auto pm    = vec_pm[lev]->const_array(mfi);
+            auto pn    = vec_pn[lev]->const_array(mfi);
+            auto visc2_r = vec_visc2_r[lev]->array(mfi);
+            auto diff2   = vec_diff2[lev]->array(mfi);
+
+            Real diff0[NCONS];
+            for (int n=0; n<NCONS; n++)
+                diff0[n] = solverChoice.tnu2[n];
+
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                Real denom  = pm(i,j,0) * pn(i,j,0);
+                Real grdscl = (denom > 0.0_rt) ? std::sqrt(1.0_rt / denom) : 0.0_rt;
+                visc2_r(i,j,k) = cff * grdscl;
+
+                for (int n = 0; n < NCONS; n++)
+                    diff2(i,j,k,n) = (diff0[n]/grdmax) * grdscl;
+            });
+        }
+
+        // Fill ghost cells for rho coefficients BEFORE psi averaging
+        Real time = 0.0_rt;
+        FillPatch(lev, time, *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r), BCVars::foextrap_periodic_bc);
+
+        // ------------------------------------------------------------
+        // Step 3: Psi coefficients = average of 4 surrounding rho
+        // (exact ROMS form, applied everywhere)
+        // ------------------------------------------------------------
+        for (MFIter mfi(*vec_visc2_p[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.validbox();
+            auto visc2_p = vec_visc2_p[lev]->array(mfi);
+            auto visc2_r = vec_visc2_r[lev]->const_array(mfi);
+
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                visc2_p(i,j,k) = 0.25_rt * (
+                    visc2_r(i-1,j-1,k) +
+                    visc2_r(i  ,j-1,k) +
+                    visc2_r(i-1,j  ,k) +
+                    visc2_r(i  ,j  ,k)
+                );
+            });
+        }
+
+        FillPatch(lev, time, *vec_visc2_p[lev], GetVecOfPtrs(vec_visc2_p), BCVars::foextrap_periodic_bc);
+
+        // Diagnostics
+        Real visc_min = vec_visc2_r[lev]->min(0,0,true);
+        Real visc_max = vec_visc2_r[lev]->max(0,0,true);
+        if (ParallelDescriptor::IOProcessor() && lev == 0)
+        {
+            Print() << "\nHorizontal mixing scaled by grid metric\n";
+            Print() << "grdmax = " << grdmax << "\n";
+            Print() << "visc2 min/max = "
+                    << visc_min << " / "
+                    << visc_max << "\n";
+        }
+
     } else {
         Abort("Don't know this horizontal mixing type");
     }
+
+    // Final FillPatch for all fields
     Real time = 0.0_rt;
-    FillPatch(lev, time, *vec_visc2_p[lev], GetVecOfPtrs(vec_visc2_p),BCVars::foextrap_periodic_bc);
-    FillPatch(lev, time, *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r),BCVars::foextrap_periodic_bc);
-    for (int n=0; n<NCONS; n++) {
-        FillPatch(lev, time, *vec_diff2[lev]  , GetVecOfPtrs(vec_diff2),BCVars::foextrap_periodic_bc,BdyVars::null,n,false);
-    }
+    FillPatch(lev, time, *vec_visc2_p[lev], GetVecOfPtrs(vec_visc2_p), BCVars::foextrap_periodic_bc);
+    FillPatch(lev, time, *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r), BCVars::foextrap_periodic_bc);
+    for (int n=0; n<NCONS; n++)
+        FillPatch(lev, time, *vec_diff2[lev], GetVecOfPtrs(vec_diff2),
+                  BCVars::foextrap_periodic_bc, BdyVars::null, n, false);
 }
 
 /**
@@ -764,31 +938,6 @@ REMORA::set_wind(int lev)
         }
 #endif
     }
-}
-/**
- * @param[in   ] lev    level to operate on
- */
-void
-REMORA::set_masks(int lev)
-{
-    if (solverChoice.mask_type == MaskType::analytic) {
-        prob->init_analytic_masks(lev,geom[lev], solverChoice, *this, *vec_mskr[lev]);
-        calculate_nodal_masks(lev);
-    } else if (solverChoice.mask_type == MaskType::netcdf) {
-#ifdef REMORA_USE_NETCDF
-        if (lev == 0) {
-            amrex::Print() << "Calling init_masks_from_netcdf level " << lev << std::endl;
-            init_masks_from_netcdf(lev);
-            amrex::Print() << "Masks loaded from netcdf file \n " << std::endl;
-        } else {
-            Real dummy_time = 0.0_rt;
-            FillCoarsePatchPC(lev, dummy_time, vec_mskr[lev].get(), vec_mskr[lev-1].get(),
-                    BCVars::foextrap_bc);
-            calculate_nodal_masks(lev);
-        }
-#endif
-    }
-    fill_3d_masks(lev);
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -738,7 +738,7 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& pn) -> Real
             {
                 Real local_min = 1.0e200_rt;
-                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int ) noexcept
                 {
                     if (k != 0) { return; }
                     local_min = amrex::min(local_min, pm(i,j,0) * pn(i,j,0));

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -674,15 +674,27 @@ REMORA::set_hmixcoef(int lev)
 {
     BL_PROFILE("REMORA::set_hmixcoef()");
 
+    // Optional AMR scaling: decrease coefficients on refined levels linearly
+    // with grid size (i.e., proportional to sqrt(cell area)). For a horizontal
+    // refinement ratio rx x ry, the effective scale factor is 1/sqrt(rx*ry).
+    Real lev_scale = 1.0_rt;
+    if ((solverChoice.scaled_to_grid_amr_scaling == ScaledToGridAMRScaling::linear) && (lev > 0)) {
+        Real rf = 1.0_rt;
+        for (int l = 0; l < lev; ++l) {
+            rf *= std::sqrt(static_cast<Real>(ref_ratio[l][0]) * static_cast<Real>(ref_ratio[l][1]));
+        }
+        lev_scale = 1.0_rt / rf;
+    }
+
     if (solverChoice.horiz_mixing_type == HorizMixingType::analytic) {
         prob->init_analytic_hmix(lev, geom[lev], solverChoice,
                                  *this, *vec_visc2_p[lev], *vec_visc2_r[lev], *vec_diff2[lev]);
 
     } else if (solverChoice.horiz_mixing_type == HorizMixingType::constant) {
-        vec_visc2_p[lev]->setVal(solverChoice.visc2);
-        vec_visc2_r[lev]->setVal(solverChoice.visc2);
+        vec_visc2_p[lev]->setVal(solverChoice.visc2 * lev_scale);
+        vec_visc2_r[lev]->setVal(solverChoice.visc2 * lev_scale);
         for (int n=0; n<NCONS; n++)
-            vec_diff2[lev]->setVal(solverChoice.tnu2[n], n, 1);
+            vec_diff2[lev]->setVal(solverChoice.tnu2[n] * lev_scale, n, 1);
 
     // Scale harmonic viscosity and diffusivity by the grid size as ROMS
     // does in Utility/ini_hmixcoef.F. Intended for curvilinear grids.
@@ -761,7 +773,19 @@ REMORA::set_hmixcoef(int lev)
         if (grdmax <= 0.0_rt)
             Abort("scaled_to_grid: grdmax <= 0");
 
-        Real visc0 = solverChoice.visc2;
+        // Optional AMR scaling: decrease coefficients on refined levels linearly
+        // with grid size (i.e., proportional to sqrt(cell area)). For a horizontal
+        // refinement ratio rx x ry, the effective scale factor is 1/sqrt(rx*ry).
+        lev_scale = 1.0_rt;
+        if ((solverChoice.scaled_to_grid_amr_scaling == ScaledToGridAMRScaling::linear) && (lev > 0)) {
+            Real rf = 1.0_rt;
+            for (int l = 0; l < lev; ++l) {
+                rf *= std::sqrt(static_cast<Real>(ref_ratio[l][0]) * static_cast<Real>(ref_ratio[l][1]));
+            }
+            lev_scale = 1.0_rt / rf;
+        }
+
+        Real visc0 = solverChoice.visc2 * lev_scale;
         Real cff   = visc0 / grdmax;
 
         // ------------------------------------------------------------
@@ -785,8 +809,9 @@ REMORA::set_hmixcoef(int lev)
                 Real grdscl = (denom > 0.0_rt) ? std::sqrt(1.0_rt / denom) : 0.0_rt;
                 visc2_r(i,j,k) = cff * grdscl;
 
-                for (int n = 0; n < NCONS; n++)
-                    diff2(i,j,k,n) = (diff0[n]/grdmax) * grdscl;
+                for (int n = 0; n < NCONS; n++) {
+                    diff2(i,j,k,n) = ((diff0[n] * lev_scale) / grdmax) * grdscl;
+                }
             });
         }
 
@@ -898,6 +923,9 @@ REMORA::set_hmixcoef(int lev)
         {
             Print() << "\nHorizontal mixing scaled by grid metric\n";
             Print() << "grdmax = " << grdmax << "\n";
+            if (solverChoice.scaled_to_grid_amr_scaling == ScaledToGridAMRScaling::linear) {
+                Print() << "AMR scaling (linear) lev_scale = " << lev_scale << "\n";
+            }
             Print() << "visc2(all)      min/max = "
                     << visc_min_all << " / "
                     << visc_max_all << "\n";

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -726,7 +726,9 @@ REMORA::set_hmixcoef(int lev)
         // ------------------------------------------------------------
         vec_visc2_r[lev]->setVal(solverChoice.visc2);
         vec_visc2_p[lev]->setVal(solverChoice.visc2);
-        vec_diff2[lev]->setVal(solverChoice.visc2);
+        for (int n = 0; n < NCONS; n++) {
+            vec_diff2[lev]->setVal(solverChoice.tnu2[n], n, 1);
+        }
 
         // NOTE: This must be GPU-safe. Do not dereference MultiFab data on host.
         // Force the reduction to run in the GPU launch region if GPUs are enabled.
@@ -804,14 +806,14 @@ REMORA::set_hmixcoef(int lev)
                 diff0[n] = solverChoice.tnu2[n];
             }
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
             {
                 Real denom  = pm(i,j,0) * pn(i,j,0);
                 Real grdscl = (denom > 0.0_rt) ? std::sqrt(1.0_rt / denom) : 0.0_rt;
-                visc2_r(i,j,k) = cff * grdscl;
+                visc2_r(i,j,0) = cff * grdscl;
 
                 for (int n = 0; n < NCONS; n++) {
-                    diff2(i,j,k,n) = ((diff0[n] * lev_scale) / grdmax) * grdscl;
+                    diff2(i,j,0,n) = ((diff0[n] * lev_scale) / grdmax) * grdscl;
                 }
             });
         }
@@ -822,7 +824,6 @@ REMORA::set_hmixcoef(int lev)
 
         // ------------------------------------------------------------
         // Step 3: Psi coefficients = average of 4 surrounding rho
-        // (exact ROMS form, applied everywhere)
         // ------------------------------------------------------------
         for (MFIter mfi(*vec_visc2_p[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
@@ -830,13 +831,13 @@ REMORA::set_hmixcoef(int lev)
             auto visc2_p = vec_visc2_p[lev]->array(mfi);
             auto visc2_r = vec_visc2_r[lev]->const_array(mfi);
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
             {
-                visc2_p(i,j,k) = 0.25_rt * (
-                    visc2_r(i-1,j-1,k) +
-                    visc2_r(i  ,j-1,k) +
-                    visc2_r(i-1,j  ,k) +
-                    visc2_r(i  ,j  ,k)
+                visc2_p(i,j,0) = 0.25_rt * (
+                    visc2_r(i-1,j-1,0) +
+                    visc2_r(i  ,j-1,0) +
+                    visc2_r(i-1,j  ,0) +
+                    visc2_r(i  ,j  ,0)
                 );
             });
         }
@@ -886,7 +887,7 @@ REMORA::set_hmixcoef(int lev)
             });
         ParallelDescriptor::ReduceRealMax(visc_max_wet);
 
-        // Mimic "apply mask_rho" convention (dry -> 0), k=0.
+        // Mimic "apply mask_rho" convention (dry -> 0).
         Real visc_min_mask0 = amrex::ReduceMin(*vec_visc2_r[lev], *vec_mskr[lev], 0,
             [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
                                       Array4<Real const> const& visc2,

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -893,9 +893,9 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& mskr) -> Real
             {
                 Real local_min = 1.0e200_rt;
-                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int) noexcept
                 {
-                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,k) : 0.0_rt;
+                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,0) : 0.0_rt;
                     local_min = amrex::min(local_min, v);
                 });
                 return local_min;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -740,7 +740,6 @@ REMORA::set_hmixcoef(int lev)
                 Real local_min = 1.0e200_rt;
                 amrex::Loop(bx, [=,&local_min] (int i, int j, int ) noexcept
                 {
-                    if (k != 0) { return; }
                     local_min = amrex::min(local_min, pm(i,j,0) * pn(i,j,0));
                 });
                 return local_min;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -757,9 +757,8 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& pn) -> Real
             {
                 Real local_max = 0.0_rt;
-                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int) noexcept
                 {
-                    if (k != 0) { return; }
                     Real denom = pm(i,j,0) * pn(i,j,0);
                     if (denom > 0.0_rt) {
                         Real G = std::sqrt(1.0_rt / denom);
@@ -861,11 +860,10 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& mskr) -> Real
             {
                 Real local_min = 1.0e200_rt;
-                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int) noexcept
                 {
-                    if (k != 0) { return; }
                     if (mskr(i,j,0) > 0.0_rt) {
-                        local_min = amrex::min(local_min, visc2(i,j,k));
+                        local_min = amrex::min(local_min, visc2(i,j,0));
                     }
                 });
                 return local_min;
@@ -878,11 +876,10 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& mskr) -> Real
             {
                 Real local_max = -1.0e200_rt;
-                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int) noexcept
                 {
-                    if (k != 0) { return; }
                     if (mskr(i,j,0) > 0.0_rt) {
-                        local_max = amrex::max(local_max, visc2(i,j,k));
+                        local_max = amrex::max(local_max, visc2(i,j,0));
                     }
                 });
                 return local_max;
@@ -898,7 +895,6 @@ REMORA::set_hmixcoef(int lev)
                 Real local_min = 1.0e200_rt;
                 amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
                 {
-                    if (k != 0) { return; }
                     const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,k) : 0.0_rt;
                     local_min = amrex::min(local_min, v);
                 });
@@ -912,10 +908,9 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& mskr) -> Real
             {
                 Real local_max = -1.0e200_rt;
-                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int) noexcept
                 {
-                    if (k != 0) { return; }
-                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,k) : 0.0_rt;
+                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,0) : 0.0_rt;
                     local_max = amrex::max(local_max, v);
                 });
                 return local_max;

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -693,8 +693,9 @@ REMORA::set_hmixcoef(int lev)
     } else if (solverChoice.horiz_mixing_type == HorizMixingType::constant) {
         vec_visc2_p[lev]->setVal(solverChoice.visc2 * lev_scale);
         vec_visc2_r[lev]->setVal(solverChoice.visc2 * lev_scale);
-        for (int n=0; n<NCONS; n++)
+        for (int n=0; n<NCONS; n++) {
             vec_diff2[lev]->setVal(solverChoice.tnu2[n] * lev_scale, n, 1);
+        }
 
     // Scale harmonic viscosity and diffusivity by the grid size as ROMS
     // does in Utility/ini_hmixcoef.F. Intended for curvilinear grids.
@@ -769,8 +770,9 @@ REMORA::set_hmixcoef(int lev)
             });
 
         ParallelDescriptor::ReduceRealMax(grdmax);
-        if (grdmax <= 0.0_rt)
+        if (grdmax <= 0.0_rt) {
             Abort("scaled_to_grid: grdmax <= 0");
+        }
 
         // Optional AMR scaling: decrease coefficients on refined levels linearly
         // with grid size (i.e., proportional to sqrt(cell area)). For a horizontal
@@ -799,8 +801,9 @@ REMORA::set_hmixcoef(int lev)
             auto diff2   = vec_diff2[lev]->array(mfi);
 
             Real diff0[NCONS];
-            for (int n=0; n<NCONS; n++)
+            for (int n=0; n<NCONS; n++) {
                 diff0[n] = solverChoice.tnu2[n];
+            }
 
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
@@ -944,9 +947,10 @@ REMORA::set_hmixcoef(int lev)
     Real time = 0.0_rt;
     FillPatch(lev, time, *vec_visc2_p[lev], GetVecOfPtrs(vec_visc2_p), BCVars::foextrap_periodic_bc);
     FillPatch(lev, time, *vec_visc2_r[lev], GetVecOfPtrs(vec_visc2_r), BCVars::foextrap_periodic_bc);
-    for (int n=0; n<NCONS; n++)
+    for (int n = 0; n < NCONS; n++) {
         FillPatch(lev, time, *vec_diff2[lev], GetVecOfPtrs(vec_diff2),
                   BCVars::foextrap_periodic_bc, BdyVars::null, n, false);
+    }
 }
 
 /**

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -739,7 +739,7 @@ REMORA::set_hmixcoef(int lev)
                                       Array4<Real const> const& pn) -> Real
             {
                 Real local_min = 1.0e200_rt;
-                amrex::Loop(bx, [=,&local_min] (int i, int j, int ) noexcept
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int) noexcept
                 {
                     local_min = amrex::min(local_min, pm(i,j,0) * pn(i,j,0));
                 });

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -700,9 +700,11 @@ REMORA::set_hmixcoef(int lev)
     //     nu0     = solverChoice.visc2
     //     kappa0  = solverChoice.tnu2[n]
     //
-    // This makes mixing strongest where grid spacing is largest,
-    // and ensures the maximum coefficient equals the user-specified value.
-    // The normalization (Gmax) is computed over the entire grid (ignoring masks).
+    // This makes mixing strongest where grid spacing is largest.
+    //
+    // NOTE: The normalization (Gmax) is computed over the entire grid (ignoring masks).
+    // Therefore, if the largest cell area occurs over land, the maximum over *wet* cells
+    // (or in masked output files) may be smaller than the user-specified value.
 
     } else if (solverChoice.horiz_mixing_type == HorizMixingType::scaled_to_grid) {
 
@@ -816,15 +818,95 @@ REMORA::set_hmixcoef(int lev)
         FillPatch(lev, time, *vec_visc2_p[lev], GetVecOfPtrs(vec_visc2_p), BCVars::foextrap_periodic_bc);
 
         // Diagnostics
-        Real visc_min = vec_visc2_r[lev]->min(0,0,true);
-        Real visc_max = vec_visc2_r[lev]->max(0,0,true);
+        // NOTE: coefficients are computed everywhere (including land). Output routines may later
+        // mask land points (e.g., to FillValue in NetCDF/plotfiles), and analysis tools may
+        // additionally apply mask_rho (setting land to 0). Report both conventions.
+        //
+        // Global (MPI-reduced) extrema over all valid cells (no ghost).
+        Real visc_min_all = vec_visc2_r[lev]->min(0,0,false);
+        Real visc_max_all = vec_visc2_r[lev]->max(0,0,false);
+
+        // Global extrema over *wet* rho points only, k=0.
+        amrex::Gpu::LaunchSafeGuard lsg_diag(true);
+        Real visc_min_wet = amrex::ReduceMin(*vec_visc2_r[lev], *vec_mskr[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& visc2,
+                                      Array4<Real const> const& mskr) -> Real
+            {
+                Real local_min = 1.0e200_rt;
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    if (mskr(i,j,0) > 0.0_rt) {
+                        local_min = amrex::min(local_min, visc2(i,j,k));
+                    }
+                });
+                return local_min;
+            });
+        ParallelDescriptor::ReduceRealMin(visc_min_wet);
+
+        Real visc_max_wet = amrex::ReduceMax(*vec_visc2_r[lev], *vec_mskr[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& visc2,
+                                      Array4<Real const> const& mskr) -> Real
+            {
+                Real local_max = -1.0e200_rt;
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    if (mskr(i,j,0) > 0.0_rt) {
+                        local_max = amrex::max(local_max, visc2(i,j,k));
+                    }
+                });
+                return local_max;
+            });
+        ParallelDescriptor::ReduceRealMax(visc_max_wet);
+
+        // Mimic "apply mask_rho" convention (dry -> 0), k=0.
+        Real visc_min_mask0 = amrex::ReduceMin(*vec_visc2_r[lev], *vec_mskr[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& visc2,
+                                      Array4<Real const> const& mskr) -> Real
+            {
+                Real local_min = 1.0e200_rt;
+                amrex::Loop(bx, [=,&local_min] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,k) : 0.0_rt;
+                    local_min = amrex::min(local_min, v);
+                });
+                return local_min;
+            });
+        ParallelDescriptor::ReduceRealMin(visc_min_mask0);
+
+        Real visc_max_mask0 = amrex::ReduceMax(*vec_visc2_r[lev], *vec_mskr[lev], 0,
+            [=] AMREX_GPU_HOST_DEVICE (Box const& bx,
+                                      Array4<Real const> const& visc2,
+                                      Array4<Real const> const& mskr) -> Real
+            {
+                Real local_max = -1.0e200_rt;
+                amrex::Loop(bx, [=,&local_max] (int i, int j, int k) noexcept
+                {
+                    if (k != 0) { return; }
+                    const Real v = (mskr(i,j,0) > 0.0_rt) ? visc2(i,j,k) : 0.0_rt;
+                    local_max = amrex::max(local_max, v);
+                });
+                return local_max;
+            });
+        ParallelDescriptor::ReduceRealMax(visc_max_mask0);
         if (ParallelDescriptor::IOProcessor() && lev == 0)
         {
             Print() << "\nHorizontal mixing scaled by grid metric\n";
             Print() << "grdmax = " << grdmax << "\n";
-            Print() << "visc2 min/max = "
-                    << visc_min << " / "
-                    << visc_max << "\n";
+            Print() << "visc2(all)      min/max = "
+                    << visc_min_all << " / "
+                    << visc_max_all << "\n";
+            Print() << "visc2(wet,k=0)  min/max = "
+                    << visc_min_wet << " / "
+                    << visc_max_wet << "\n";
+            Print() << "visc2(mask->0)  min/max = "
+                    << visc_min_mask0 << " / "
+                    << visc_max_mask0 << "\n";
         }
 
     } else {

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -51,6 +51,11 @@ enum class HorizMixingType {
     analytic, constant, scaled_to_grid
 };
 
+/** \brief How to scale scaled_to_grid coefficients on AMR levels */
+enum class ScaledToGridAMRScaling {
+    none, linear
+};
+
 /** \brief stability function for GLS */
 enum class GLS_StabilityType {
     Canuto_A, Canuto_B, Galperin
@@ -390,6 +395,19 @@ struct SolverChoice {
         pp.queryAdd("tnu2_salt",tnu2_salt);
         pp.queryAdd("tnu2_temp",tnu2_temp);
         pp.queryAdd("tnu2_scalar",tnu2_scalar);
+
+        // For scaled_to_grid runs with AMR refinement: optionally scale the coefficients
+        // by the horizontal refinement ratio (linear in grid size).
+        static std::string scaled_to_grid_amr_scaling_string = "none";
+        pp.queryAdd("scaled_to_grid_amr_scaling", scaled_to_grid_amr_scaling_string);
+        if (amrex::toLower(scaled_to_grid_amr_scaling_string) == "none") {
+            scaled_to_grid_amr_scaling = ScaledToGridAMRScaling::none;
+        } else if (amrex::toLower(scaled_to_grid_amr_scaling_string) == "linear") {
+            scaled_to_grid_amr_scaling = ScaledToGridAMRScaling::linear;
+        } else {
+            amrex::Abort("Don't know this scaled_to_grid_amr_scaling option");
+        }
+
         tnu2.resize(NCONS);
         if (use_salt) {
             tnu2[0] = tnu2_temp;
@@ -642,6 +660,7 @@ struct SolverChoice {
     // Mixing type and parameters
     VertMixingType vert_mixing_type;
     HorizMixingType horiz_mixing_type;
+    ScaledToGridAMRScaling scaled_to_grid_amr_scaling = ScaledToGridAMRScaling::none;
     GLS_StabilityType gls_stability_type;
 
     // Type for grid scale (pm and pn)

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -48,7 +48,7 @@ enum class VertMixingType {
 
 /** \brief horizontal viscosity/diffusion type */
 enum class HorizMixingType {
-    analytic, constant
+    analytic, constant, scaled_to_grid
 };
 
 /** \brief stability function for GLS */
@@ -381,6 +381,8 @@ struct SolverChoice {
             horiz_mixing_type = HorizMixingType::analytic;
         } else if (amrex::toLower(horiz_mixing_type_string) == "constant") {
             horiz_mixing_type = HorizMixingType::constant;
+        } else if (amrex::toLower(horiz_mixing_type_string) == "scaled_to_grid") {
+            horiz_mixing_type = HorizMixingType::scaled_to_grid;
         } else {
             amrex::Abort("Don't know this horizontal mixing type");
         }


### PR DESCRIPTION
This PR adds and documents a new horizontal mixing option, `remora.horizontal_mixing_type = "scaled_to_grid"`, implementing the ROMS-style grid-dependent scaling of horizontal harmonic viscosity and tracer diffusivity on curvilinear grids. When enabled, REMORA also outputs the resulting spatially varying coefficients as **2D, vertically homogeneous, time-invariant** fields (NetCDF + plotfiles).

## Physical description
ROMS provides a commonly used option (`VISC_GRID` / `DIFF_GRID`) that scales horizontal harmonic mixing coefficients by a grid-size metric so mixing is stronger where the mesh is coarser (larger cell area).

- Define a grid factor (ROMS `grdscl`) at rho points:
  - $$A(i,j) = 1/(pm(i,j)\,pn(i,j))$$
  - $$G(i,j) = \sqrt{A(i,j)} = \sqrt{1/(pm(i,j)\,pn(i,j))}$$

- Normalize by the global maximum $$G_{\max}$$ and scale coefficients:
  - $$\nu(i,j) = \nu_0 \, G(i,j) / G_{\max}$$
  - $$\kappa_n(i,j) = \kappa_{0,n} \, G(i,j) / G_{\max}$$

This preserves the user-specified coefficient as the maximum **over the normalization region** while varying spatially with grid size. Because the normalization uses an *unmasked* global maximum, if the largest cell area occurs over land, the maximum over *wet* cells (or after applying `mask_rho` in post-processing) can be smaller than the user-specified value.

## Implementation 
- Computes `Gmax` on the `k=0` plane using `pm` and `pn`, with a runtime abort if `pm*pn <= 0` is detected (invalid grid metrics).
- Fills ghost cells for coefficient fields before psi-point averaging so the ROMS-style 4-point average for `visc2_p` is well-defined near boundaries.
- Adds clearer runtime diagnostics printing extrema for:
  - raw coefficients over all cells
  - wet-only coefficients (`msk>0`)
  - a “mask->0” convention matching typical offline checks

## Output behavior (NetCDF + plotfiles)
When `scaled_to_grid` is active:
- NetCDF output writes `visc2` and `diff2_*` as **static 2D variables** (no `ocean_time`, no `s_rho`).
- AMReX plotfile output writes a one-time **static coefficient plotfile** named `<plot_file>_hmixcoef` (and omits these coefficients from the regular time-series plotfiles). I'm not sure if this is the best solution once we update the code to work with refined meshes, so this is temporary. 

## Docs
- Updated `Docs/sphinx_doc/Inputs.rst` to describe the scaling, the normalization region, and the masking caveat (wet max may be < `nu0` if the global max is over land).
- Updated `Docs/sphinx_doc/Plotfiles.rst` to document that these coefficient fields are 2D and how they’re written (static NetCDF variables / static AMReX plotfile).

## Testing
- Ran CTest regression suite: `ctest -L regression` (16/16 passed) on a CPU test build.
- Verified `scaled_to_grid` coefficient fields match offline computation to machine precision for a representative grid.
- Verified with TXLA ROMS model

When the model is running, the print statement will look like this:
```
Horizontal mixing scaled by grid metric
grdmax = 3410.613288
visc2(all)      min/max = 0.9053661693 / 5
visc2(wet,k=0)  min/max = 1.253506394 / 4.008579005
visc2(mask->0)  min/max = 0 / 4.008579005
```
Attached is the python script used to produce the plots below for the TXLA model.
<img width="1154" height="823" alt="image" src="https://github.com/user-attachments/assets/1e1c5143-aabb-4fc1-bb70-96e480aa3dff" />
<img width="1209" height="823" alt="image" src="https://github.com/user-attachments/assets/cd877995-15d5-42dd-af3b-041782c4796d" />
[check_var_hmix.py](https://github.com/user-attachments/files/26544460/check_var_hmix.py)
