### PR TITLE
time series in NCTimeSeries and NCTimeSeriesRiver can be split over multiple files

### DIFF
--- a/Docs/sphinx_doc/Climatology.rst
+++ b/Docs/sphinx_doc/Climatology.rst
@@ -10,7 +10,7 @@ Nudging to climatology
 
 REMORA supports nudging to climatology both on the boundaries and in an interior sponge region. Nudging at the boundaries is discussed in :ref:`Boundary Conditions<sec:domainBCs>`.
 
-The climatology history and nudging coefficients are read from NetCDF files. The nudging coefficients are expected to be in units of 1/day, as in ROMS.
+The climatology history and nudging coefficients are read from NetCDF files. The climatology history may come from a single file or a time-ordered list of files. The nudging coefficients are expected to be in units of 1/day, as in ROMS.
 
 For AMR runs, climatology fields are read and temporally interpolated on level 0, then interpolated to higher AMR levels as needed. This allows one climatology dataset on the coarse grid to drive nudging on all levels.
 
@@ -43,4 +43,3 @@ The 3D velocity components are updated in the right-hand side term ``ru`` accord
    \mathrm{RHS}_{u} = \mathrm{RHS}_{u} + C_{\mathrm{M3}} \frac{H_{z}}{mn} \left(u_{\mathrm{clim}} - u_{\mathrm{old}}\right)
 
 or similar for v. :math:`C_{\mathrm{M3}}` is the nudging coefficient and :math:`u_{\mathrm{clim}}` is the climatology value read from file. :math:`\mathrm{RHS}_{u}` is the variable ``ru`` and :math:`u_{\mathrm{old}}` is the value of :math:`u` at the prior time step.
-

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -125,10 +125,10 @@ List of Parameters
 |                                   |                                   |                 |                                 |
 |                                   |                                   |                 | or ``flather``.                 |
 +-----------------------------------+-----------------------------------+-----------------+---------------------------------+
-| **remora.nc_frc_file**            | forcing data NetCDF               | string          | must be set                     |
+| **remora.nc_frc_file**            | forcing data NetCDF               | string or list  | must be set                     |
 |                                   |                                   |                 |                                 |
 |                                   |                                   |                 | if ``remora.wind_type``         |
-|                                   | file name                         |                 |                                 |
+|                                   | file name(s)                      | of strings      |                                 |
 |                                   |                                   |                 | or ``remora.smflux_type``       |
 |                                   |                                   |                 |                                 |
 |                                   |                                   |                 | equal ``netcdf``                |
@@ -160,6 +160,8 @@ Notes
 -----
 
 -  ``nc_bdry_file`` must either be a string or a space-separated list of strings of boundary data files. They must be in time series order.
+
+-  ``nc_frc_file`` may be either a string or a space-separated list of strings of forcing data files. They must be in time series order.
 
 -  The time variables in the boundary files may be different for each boundary variable. Any that are not individually specified with
    ``remora.bdy_{var}_time_varname`` will default to the variable name given by ``bdy_time_varname``.
@@ -1110,8 +1112,9 @@ List of Bulk Fluxes parameters
    **srflx_from_netcdf**, **longwave_down_from_netcdf**,
    **rain_from_netcdf**, **cloud_from_netcdf**, or **EminusP_from_netcdf**
    to true), these variables are read from the file
-   specified by **remora.nc_frc_file** (see :ref:`list-of-parameters surface-forcing`).
-   The NetCDF file must contain variables named ``Tair``, ``qair``, ``Pair``,
+   or files specified by **remora.nc_frc_file** (see :ref:`list-of-parameters surface-forcing`).
+   If multiple forcing files are provided, REMORA concatenates their time axes in
+   the order listed in the inputs file. The NetCDF data must contain variables named ``Tair``, ``qair``, ``Pair``,
    ``swrad``, ``rain``, ``cloud``, and ``EminusP`` respectively, with the same
    spatial dimensions as the level 0 (coarsest) model grid. If atmospheric forcing
    is not loaded from NetCDF files, spatially uniform constant values can be
@@ -1225,11 +1228,11 @@ List of Parameters
 |                                       |                             |              |                           |
 |                                       | to climatology              |              |                           |
 +---------------------------------------+-----------------------------+--------------+---------------------------+
-| **remora.nc_clim_his_file**           | NetCDF file name for        | string       | must be set if one of     |
+| **remora.nc_clim_his_file**           | NetCDF file name(s) for     | string or    | must be set if one of     |
 |                                       |                             |              |                           |
-|                                       | climatology data            |              | ``do_*_clim_nudg``        |
+|                                       | climatology data            | list         | ``do_*_clim_nudg``        |
 |                                       |                             |              |                           |
-|                                       |                             |              | flags is true             |
+|                                       |                             | of strings   | flags is true             |
 +---------------------------------------+-----------------------------+--------------+---------------------------+
 | **remora.nc_clim_coeff_file**         | NetCDF file name for        | string       | must be set if one of     |
 |                                       |                             |              |                           |
@@ -1270,7 +1273,9 @@ List of Parameters
 
    For AMR runs, climatology fields are read on level 0 and temporally
    interpolated there. REMORA then interpolates those fields to finer AMR
-   levels for nudging updates.
+   levels for nudging updates. ``remora.nc_clim_his_file`` may be a single file
+   or a space-separated list of files. When multiple files are provided, they
+   must be listed in time series order.
 
 Rivers (point sources)
 ======================
@@ -1290,9 +1295,9 @@ These parameters are used to configure NetCDF-specified river-like point sources
 |                             |                                  |              |                                   |
 |                             | apply momentum                   |              |                                   |
 +-----------------------------+----------------------------------+--------------+-----------------------------------+
-| **remora.nc_river_file**    | NetCDF file for river sources    | string       | must be set if                    |
+| **remora.nc_river_file**    | NetCDF file(s) for river         | string or    | must be set if                    |
 |                             |                                  |              |                                   |
-|                             |                                  |              | ``do_rivers``                     |
+|                             | sources                          | list         | ``do_rivers``                     |
 +-----------------------------+----------------------------------+--------------+-----------------------------------+
 | **remora.riv_time_varname** | Name of time variable            | string       | ``river_time``                    |
 +-----------------------------+----------------------------------+--------------+-----------------------------------+
@@ -1308,6 +1313,12 @@ These parameters are used to configure NetCDF-specified river-like point sources
 |                             |                                  |              |                                   |
 |                             | scalar sources                   |              | if ``do_rivers``                  |
 +-----------------------------+----------------------------------+--------------+-----------------------------------+
+
+.. note::
+
+   ``remora.nc_river_file`` may be either a single file or a space-separated
+   list of files. If multiple river files are provided, they must be listed in
+   time series order.
 
 Runtime Error Checking
 ======================

--- a/Source/IO/REMORA_NCTimeSeries.H
+++ b/Source/IO/REMORA_NCTimeSeries.H
@@ -17,7 +17,7 @@ class NCTimeSeries
 {
     public:
         /** \brief Constructor */
-        NCTimeSeries (const std::string a_file_name,
+        NCTimeSeries (const amrex::Vector<std::string>& a_file_names,
                       const std::string a_field_name,
                       const std::string a_time_name,
                       const amrex::Box& a_domain,
@@ -43,8 +43,8 @@ class NCTimeSeries
         amrex::IntVect cumulative_ref_ratio (int lev,
                                              const amrex::Vector<amrex::IntVect>& ref_ratio) const;
 
-        /// File name to read from
-        std::string file_name;
+        /// File names to read from
+        amrex::Vector<std::string> file_names;
         /// Field name in netcdf file
         std::string field_name;
         /// Field name for time series in netcdf file
@@ -60,6 +60,10 @@ class NCTimeSeries
 
         /// Time points in netcdf file
         amrex::Vector<amrex::Real> ocean_times;
+        /// File index to access a particular time
+        amrex::Vector<int> file_for_time;
+        /// Offset to access a particular time within its file
+        amrex::Vector<int> file_itime_offset;
         /// Time index immediately before the last time interpolated to
         int i_time_before;
         /// Time in ocean_times immediately before the last time interpolated to

--- a/Source/IO/REMORA_NCTimeSeries.cpp
+++ b/Source/IO/REMORA_NCTimeSeries.cpp
@@ -9,7 +9,7 @@
 
 #ifdef REMORA_USE_NETCDF
 /**
- * @param[in   ] a_file_name          file name to read from
+ * @param[in   ] a_file_names         vector of file name(s) to read from
  * @param[in   ] a_field_name         name of field to read in
  * @param[in   ] a_time_name          name of time variable in NetCDF file
  * @param[in   ] a_domain             simulation domain
@@ -17,11 +17,11 @@
  * @param[in   ] a_is2d               Whether the variable we're working with is 2D
  * @param[in   ] a_save_interpolated  Whether the interpolated value should be saved internally
  */
-NCTimeSeries::NCTimeSeries (const std::string a_file_name, const std::string a_field_name,
+NCTimeSeries::NCTimeSeries (const amrex::Vector<std::string>& a_file_names, const std::string a_field_name,
                             const std::string a_time_name,
                             const amrex::Box& a_domain,
                             amrex::MultiFab* a_mf_var, bool a_is2d, bool a_save_interpolated) {
-    file_name = a_file_name;
+    file_names.assign(a_file_names.begin(), a_file_names.end());
     time_name = a_time_name;
     field_name = a_field_name;
     domain = a_domain;
@@ -32,7 +32,7 @@ NCTimeSeries::NCTimeSeries (const std::string a_file_name, const std::string a_f
 
 void NCTimeSeries::Initialize() {
     // open file
-    amrex::Print() << "Loading " << field_name << " from NetCDF file " << file_name << std::endl;
+    amrex::Print() << "Loading " << field_name << " from NetCDF file(s)" << std::endl;
 
     // The time field can have any number of names, depending on the field.
     // If not specified in input file (time_name.empty()) then set it by default
@@ -49,27 +49,33 @@ void NCTimeSeries::Initialize() {
         }
     }
 
-    // Check units of time stamps; should be days
-    std::string unit_str = ReadNetCDFVarAttrStr(file_name, time_name, "units"); // works on proc 0
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        if (unit_str.find("days") == std::string::npos) {
-            amrex::Print() << "Units of ocean_time given as: " << unit_str << std::endl;
-            amrex::Abort("Units must be in days.");
-        }
-    }
-    // get times and put in array
-    using RARRAY = NDArray<amrex::Real>;
-    amrex::Vector<RARRAY> array_ts(1);
-    ReadNetCDFFile(file_name, {time_name}, array_ts); // filled only on proc 0
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        int ntimes_io = array_ts[0].get_vshape()[0];
-        for (int nt(0); nt < ntimes_io; nt++)
+    for (int ifile = 0; ifile < file_names.size(); ++ifile) {
+        const std::string& file_name = file_names[ifile];
+
+        // Check units of time stamps; should be days
+        std::string unit_str = ReadNetCDFVarAttrStr(file_name, time_name, "units"); // works on proc 0
+        if (amrex::ParallelDescriptor::IOProcessor())
         {
-            // Convert ocean time from days to seconds
-            ocean_times.push_back((*(array_ts[0].get_data() + nt)) * amrex::Real(60.0) * amrex::Real(60.0) * amrex::Real(24.0));
-            // amrex::Print() << "TIMES " << ocean_times[nt] << std::endl;
+            if (unit_str.find("days") == std::string::npos) {
+                amrex::Print() << "Units of ocean_time given as: " << unit_str << std::endl;
+                amrex::Abort("Units must be in days.");
+            }
+        }
+
+        // get times and put in array
+        using RARRAY = NDArray<amrex::Real>;
+        amrex::Vector<RARRAY> array_ts(1);
+        ReadNetCDFFile(file_name, {time_name}, array_ts); // filled only on proc 0
+        if (amrex::ParallelDescriptor::IOProcessor())
+        {
+            int ntimes_io = array_ts[0].get_vshape()[0];
+            for (int nt(0); nt < ntimes_io; nt++)
+            {
+                // Convert ocean time from days to seconds
+                ocean_times.push_back((*(array_ts[0].get_data() + nt)) * amrex::Real(60.0) * amrex::Real(60.0) * amrex::Real(24.0));
+                file_for_time.push_back(ifile);
+                file_itime_offset.push_back(nt);
+            }
         }
     }
     int ntimes = ocean_times.size();
@@ -84,8 +90,12 @@ void NCTimeSeries::Initialize() {
     amrex::ParallelDescriptor::Bcast(&ntimes,1,ioproc);
     if (!(amrex::ParallelDescriptor::IOProcessor())) {
         ocean_times.resize(ntimes);
+        file_for_time.resize(ntimes);
+        file_itime_offset.resize(ntimes);
     }
     amrex::ParallelDescriptor::Bcast(ocean_times.data(), ocean_times.size(), ioproc);
+    amrex::ParallelDescriptor::Bcast(file_for_time.data(), file_for_time.size(), ioproc);
+    amrex::ParallelDescriptor::Bcast(file_itime_offset.data(), file_itime_offset.size(), ioproc);
 
     // Initialize MultiFabs
     // NetCDF data is always read and temporally interpolated on level 0.
@@ -226,7 +236,11 @@ void NCTimeSeries::read_in_at_time (amrex::MultiFab* mf, int itime) {
     amrex::Vector<std::string> NC_names;
     amrex::Vector<enum NC_Data_Dims_Type> NC_dim_types;
 
-    amrex::Print() << "Reading in " << field_name << " at  time index " << itime << " from " << file_name << std::endl;
+    const std::string& file_name = file_names[file_for_time[itime]];
+    const int itime_offset = file_itime_offset[itime];
+
+    amrex::Print() << "Reading in " << field_name << " at time index " << itime
+                   << " from " << file_name << std::endl;
 
     NC_fabs.push_back(&NC_fab) ; NC_names.push_back(field_name);
 
@@ -236,7 +250,8 @@ void NCTimeSeries::read_in_at_time (amrex::MultiFab* mf, int itime) {
         NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE);
     }
 
-    BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(domain, file_name, NC_names, NC_dim_types, NC_fabs, true, itime);
+    BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(domain, file_name, NC_names, NC_dim_types,
+                                                          NC_fabs, true, itime_offset);
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())

--- a/Source/IO/REMORA_NCTimeSeriesBoundary.cpp
+++ b/Source/IO/REMORA_NCTimeSeriesBoundary.cpp
@@ -9,7 +9,7 @@
 /**
  * @param[in   ] a_lev                level at which we will store the data
  * @param[in   ] a_geom               Vector of Geometry objects at all levels
- * @param[in   ] a_file_name          file name to read from
+ * @param[in   ] a_file_name          vector of file name(s) to read from
  * @param[in   ] a_field_name         name of field to read in
  * @param[in   ] a_time_name          name of time variable in NetCDF file
  * @param[in   ] a_index_type         nodality of data field
@@ -80,7 +80,6 @@ void NCTimeSeriesBoundary::Initialize()
                 bry_times.push_back((*(array_ts[0].get_data() + nt)) * amrex::Real(60.0) * amrex::Real(60.0) * amrex::Real(24.0));
                 file_for_time.push_back(ifile);
                 file_itime_offset.push_back(nt);
-                // amrex::Print() << "TIMES " << bry_times[nt] << std::endl;
             }
         }
     }

--- a/Source/IO/REMORA_NCTimeSeriesRiver.H
+++ b/Source/IO/REMORA_NCTimeSeriesRiver.H
@@ -12,7 +12,7 @@
 class NCTimeSeriesRiver
 {
     public:
-        NCTimeSeriesRiver (const std::string a_file_name,
+        NCTimeSeriesRiver (const amrex::Vector<std::string>& a_file_names,
                            const std::string a_field_name,
                            const std::string a_time_name,
                            const int a_nz, const int a_use_vert_integ=0);
@@ -43,8 +43,8 @@ class NCTimeSeriesRiver
         void read_in_at_time (amrex::FArrayBox* vec, int itime);
     private:
 
-        /// File name to read from
-        std::string file_name;
+        /// File names to read from
+        amrex::Vector<std::string> file_names;
         /// Field name in netcdf file
         std::string field_name;
         /// Field name for time series in netcdf file
@@ -59,6 +59,10 @@ class NCTimeSeriesRiver
 
         /// Time points in netcdf file
         amrex::Vector<amrex::Real> river_times;
+        /// File index to access a particular time
+        amrex::Vector<int> file_for_time;
+        /// Offset to access a particular time within its file
+        amrex::Vector<int> file_itime_offset;
         /// Time index immediately before the last time interpolated to
         int i_time_before;
         /// Time in ocean_time immediately before the last time interpolated to

--- a/Source/IO/REMORA_NCTimeSeriesRiver.cpp
+++ b/Source/IO/REMORA_NCTimeSeriesRiver.cpp
@@ -6,10 +6,18 @@
 #include <string>
 
 #ifdef REMORA_USE_NETCDF
-NCTimeSeriesRiver::NCTimeSeriesRiver (const std::string a_file_name, const std::string a_field_name,
+
+/**
+ * @param[in   ] a_file_names         vector of file name(s) to read from
+ * @param[in   ] a_field_name         name of field to read in
+ * @param[in   ] a_time_name          name of time variable in NetCDF file
+ * @param[in   ] a_nz                 number of vertical levels in domain
+ * @param[in   ] a_use_vert_integ     whether the data in the file is vertically integrated
+ */
+NCTimeSeriesRiver::NCTimeSeriesRiver (const amrex::Vector<std::string>& a_file_names, const std::string a_field_name,
                                       const std::string a_time_name,
                                       const int a_nz, const int a_use_vert_integ) {
-    file_name = a_file_name;
+    file_names.assign(a_file_names.begin(), a_file_names.end());
     time_name = a_time_name;
     field_name = a_field_name;
     nz   = a_nz;
@@ -18,7 +26,7 @@ NCTimeSeriesRiver::NCTimeSeriesRiver (const std::string a_file_name, const std::
 
 void NCTimeSeriesRiver::Initialize() {
     // open file
-    amrex::Print() << "Loading " << field_name << " from rivers NetCDF file " << file_name << std::endl;
+    amrex::Print() << "Loading " << field_name << " from rivers NetCDF file(s)" << std::endl;
 
     // The time field can have any number of names, depending on the field.
     // If not specified in input file (time_name.empty()) then set it by default
@@ -27,27 +35,33 @@ void NCTimeSeriesRiver::Initialize() {
         time_name = "river_time";
     }
 
-    // Check units of time stamps; should be days
-    std::string unit_str = ReadNetCDFVarAttrStr(file_name, time_name, "units"); // works on proc 0
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        if (unit_str.find("days") == std::string::npos) {
-            amrex::Print() << "Units of river_time given as: " << unit_str << std::endl;
-            amrex::Abort("Units must be in days.");
-        }
-    }
-    // get times and put in array
-    using RARRAY = NDArray<amrex::Real>;
-    amrex::Vector<RARRAY> array_ts(1);
-    ReadNetCDFFile(file_name, {time_name}, array_ts); // filled only on proc 0
-    if (amrex::ParallelDescriptor::IOProcessor())
-    {
-        int ntimes_io = array_ts[0].get_vshape()[0];
-        for (int nt(0); nt < ntimes_io; nt++)
+    for (int ifile = 0; ifile < file_names.size(); ++ifile) {
+        const std::string& file_name = file_names[ifile];
+
+        // Check units of time stamps; should be days
+        std::string unit_str = ReadNetCDFVarAttrStr(file_name, time_name, "units"); // works on proc 0
+        if (amrex::ParallelDescriptor::IOProcessor())
         {
-            // Convert river time from days to seconds
-            river_times.push_back((*(array_ts[0].get_data() + nt)) * amrex::Real(60.0) * amrex::Real(60.0) * amrex::Real(24.0));
-            // amrex::Print() << "TIMES " << river_times[nt] << std::endl;
+            if (unit_str.find("days") == std::string::npos) {
+                amrex::Print() << "Units of river_time given as: " << unit_str << std::endl;
+                amrex::Abort("Units must be in days.");
+            }
+        }
+
+        // get times and put in array
+        using RARRAY = NDArray<amrex::Real>;
+        amrex::Vector<RARRAY> array_ts(1);
+        ReadNetCDFFile(file_name, {time_name}, array_ts); // filled only on proc 0
+        if (amrex::ParallelDescriptor::IOProcessor())
+        {
+            int ntimes_io = array_ts[0].get_vshape()[0];
+            for (int nt(0); nt < ntimes_io; nt++)
+            {
+                // Convert river time from days to seconds
+                river_times.push_back((*(array_ts[0].get_data() + nt)) * amrex::Real(60.0) * amrex::Real(60.0) * amrex::Real(24.0));
+                file_for_time.push_back(ifile);
+                file_itime_offset.push_back(nt);
+            }
         }
     }
     int ntimes = river_times.size();
@@ -62,10 +76,14 @@ void NCTimeSeriesRiver::Initialize() {
     amrex::ParallelDescriptor::Bcast(&ntimes,1,ioproc);
     if (!(amrex::ParallelDescriptor::IOProcessor())) {
         river_times.resize(ntimes);
+        file_for_time.resize(ntimes);
+        file_itime_offset.resize(ntimes);
     }
     amrex::ParallelDescriptor::Bcast(river_times.data(), river_times.size(), ioproc);
+    amrex::ParallelDescriptor::Bcast(file_for_time.data(), file_for_time.size(), ioproc);
+    amrex::ParallelDescriptor::Bcast(file_itime_offset.data(), file_itime_offset.size(), ioproc);
 
-    auto ncf = ncutils::NCFile::open(file_name, NC_NOCLOBBER );
+    auto ncf = ncutils::NCFile::open(file_names[0], NC_NOCLOBBER );
     if (amrex::ParallelDescriptor::IOProcessor())
     {
         std::vector<MPI_Offset> shape = ncf.var(field_name).shape();
@@ -87,12 +105,12 @@ void NCTimeSeriesRiver::Initialize() {
         amrex::Vector<amrex::FArrayBox*> NC_fabs;
         amrex::Vector<std::string> NC_names;
         amrex::Vector<enum NC_Data_Dims_Type> NC_dim_types;
-        amrex::Print() << "Reading in river_Vshape from " << file_name << std::endl;
+        amrex::Print() << "Reading in river_Vshape from " << file_names[0] << std::endl;
 
         fab_vshape = new amrex::FArrayBox();
         NC_fabs.push_back(fab_vshape); NC_names.push_back("river_Vshape");
         NC_dim_types.push_back(NC_Data_Dims_Type::BT_Riv);
-        BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(vshape_box, file_name, NC_names, NC_dim_types, NC_fabs);
+        BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(vshape_box, file_names[0], NC_names, NC_dim_types, NC_fabs);
     }
 
     nzbox = (use_vert_integ) ? 1 : nz;
@@ -155,7 +173,11 @@ void NCTimeSeriesRiver::read_in_at_time (amrex::FArrayBox* fab_dat, int itime) {
     amrex::Vector<enum NC_Data_Dims_Type> NC_dim_types;
     // actual dims don't really matter here; only lower is used in call
 
-    amrex::Print() << "Reading in " << field_name << " at  time index " << itime << " from " << file_name << std::endl;
+    const std::string& file_name = file_names[file_for_time[itime]];
+    const int itime_offset = file_itime_offset[itime];
+
+    amrex::Print() << "Reading in " << field_name << " at time index " << itime
+                   << " from " << file_name << std::endl;
 
     NC_fabs.push_back(&NC_fab) ; NC_names.push_back(field_name);
 
@@ -168,7 +190,7 @@ void NCTimeSeriesRiver::read_in_at_time (amrex::FArrayBox* fab_dat, int itime) {
     amrex::Box riv_domain(amrex::IntVect(0,0,0), amrex::IntVect(nriv-1,0,nz-1));
     amrex::Box fab_domain(amrex::IntVect(0,0,0), amrex::IntVect(nriv-1,0,nzbox-1));
 
-    BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(riv_domain, file_name, NC_names, NC_dim_types, NC_fabs, true, itime);
+    BuildFABsFromNetCDFFile<amrex::FArrayBox,amrex::Real>(riv_domain, file_name, NC_names, NC_dim_types, NC_fabs, true, itime_offset);
 
     auto dat_array = fab_dat->array();
     auto tmp_array = NC_fabs[0]->const_array();

--- a/Source/IO/REMORA_ReadFromInitNetcdf.cpp
+++ b/Source/IO/REMORA_ReadFromInitNetcdf.cpp
@@ -218,13 +218,16 @@ read_clim_nudg_coeff_from_netcdf (int /*lev*/,
 
 /**
  * @param lev            level of data to read
- * @param fname          file name to read from
+ * @param fnames         file name(s) to read from
  * @param field_name     field name to read
  * @param vec_dat        vector to fill data
  */
 //template <typename DType>
-void read_vec_from_netcdf (int /*lev*/, const std::string& fname, const std::string& field_name, amrex::Vector<int>& vec_dat)
+void read_vec_from_netcdf (int /*lev*/, const amrex::Vector<std::string>& fnames, const std::string& field_name, amrex::Vector<int>& vec_dat)
 {
+    AMREX_ALWAYS_ASSERT(!fnames.empty());
+    const std::string& fname = fnames[0];
+
     amrex::Print() << "Reading " << field_name << " from NetCDF file" << std::endl;
 
     // get x-positions and put in array

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -80,8 +80,7 @@ read_clim_nudg_coeff_from_netcdf (int lev, const Box& domain, const std::string&
                                   FArrayBox& NC_SaltNC_fab);
 
 /** \brief helper function to read in vector of data from netcdf */
-//template <typename DType>
-void read_vec_from_netcdf (int lev, const std::string& fname, const std::string& field_name, amrex::Vector<int>& vec_dat);
+void read_vec_from_netcdf (int lev, const amrex::Vector<std::string>& fnames, const std::string& field_name, amrex::Vector<int>& vec_dat);
 
 /**
  * @param lev Integer specifying the current level
@@ -439,7 +438,7 @@ REMORA::init_masks_from_netcdf (int lev)
 void
 REMORA::init_bdry_from_netcdf (int lev)
 {
-    if (nc_bdry_file.empty()) {
+    if (nc_bdry_file.empty() || nc_bdry_file[0].empty()) {
         amrex::Error("NetCDF boundary file name must be provided via input");
     }
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1392,12 +1392,13 @@ private:
     /** \brief NetCDF boundary data */
     static amrex::Vector<std::string> nc_bdry_file;
 
-    /** \brief NetCDF forcing file */
-    std::string nc_frc_file;
-    std::string nc_riv_file;
+    /** \brief NetCDF forcing file(s) */
+    amrex::Vector<std::string> nc_frc_file;
+    /** \brief NetCDF river file(s) */
+    amrex::Vector<std::string> nc_riv_file;
 
-    /** \brief NetCDF climatology history file */
-    std::string nc_clim_his_file;
+    /** \brief NetCDF climatology history file(s) */
+    amrex::Vector<std::string> nc_clim_his_file;
     /** \brief NetCDF climatology coefficient file */
     std::string nc_clim_coeff_file;
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -1085,7 +1085,7 @@ REMORA::init_only (int lev, Real time)
         init_clim_nudg_coeff(lev);
 
         if (solverChoice.do_any_clim_nudg && lev == 0) {
-            if (nc_clim_his_file.empty()) {
+            if (nc_clim_his_file.empty() || nc_clim_his_file[0].empty()) {
                 amrex::Error("NetCDF climatology file name must be provided via input");
             }
             if (solverChoice.do_m2_clim_nudg) {
@@ -1123,7 +1123,7 @@ REMORA::init_only (int lev, Real time)
 
     // This will be a non-op if forcings specified analytically
     if (solverChoice.wind_type == WindType::netcdf && lev == 0) {
-        if (nc_frc_file.empty()) {
+        if (nc_frc_file.empty() || nc_frc_file[0].empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for winds");
         }
         Uwind_data_from_file.reset(new NCTimeSeries(nc_frc_file, "Uwind", frc_time_varname, geom[lev].Domain(),vec_uwind[lev].get(), true, false));
@@ -1161,7 +1161,7 @@ REMORA::init_only (int lev, Real time)
             EminusP_data_from_file->Initialize();
         }
     } else if (solverChoice.smflux_type == SMFluxType::netcdf && lev == 0) {
-        if (nc_frc_file.empty()) {
+        if (nc_frc_file.empty() || nc_frc_file[0].empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for surface momentum fluxes");
         }
         sustr_data_from_file.reset(new NCTimeSeries(nc_frc_file, "sustr", frc_time_varname, geom[lev].Domain(),vec_sustr[lev].get(), true, false));
@@ -1170,7 +1170,7 @@ REMORA::init_only (int lev, Real time)
         svstr_data_from_file->Initialize();
     }
     if (solverChoice.longwave_down_from_netcdf && lev == 0) {
-        if (nc_frc_file.empty()) {
+        if (nc_frc_file.empty() || nc_frc_file[0].empty()) {
             amrex::Error("NetCDF forcing file name must be provided via input for longwave radiation");
         }
             longwave_down_data_from_file.reset(new NCTimeSeries(nc_frc_file, solverChoice.longwave_netcdf_varname, frc_time_varname,
@@ -1179,6 +1179,9 @@ REMORA::init_only (int lev, Real time)
     }
 
     if (solverChoice.do_rivers) {
+        if (nc_riv_file.empty() || nc_riv_file[0].empty()) {
+            amrex::Error("NetCDF river file name must be provided via input for rivers");
+        }
         auto dom = geom[0].Domain();
         int nz = dom.length(2);
         river_source_cons.resize(NCONS);
@@ -1468,13 +1471,25 @@ REMORA::ReadParameters ()
         pp.queryarr("nc_bdry_file", nc_bdry_file);
 
         // Also only read forcings at level 0 (for now)
-        pp.queryAdd("nc_frc_file", nc_frc_file);
+        if (pp.contains("nc_frc_file")) {
+            int num_files = pp.countval("nc_frc_file");
+            nc_frc_file.resize(num_files);
+            pp.queryarr("nc_frc_file", nc_frc_file, 0, num_files);
+        }
 
         // Get river file
-        pp.queryAdd("nc_river_file", nc_riv_file);
+        if (pp.contains("nc_river_file")) {
+            int num_files = pp.countval("nc_river_file");
+            nc_riv_file.resize(num_files);
+            pp.queryarr("nc_river_file", nc_riv_file, 0, num_files);
+        }
 
         // Read in file names for climatology history and nudging weights
-        pp.queryAdd("nc_clim_his_file", nc_clim_his_file);
+        if (pp.contains("nc_clim_his_file")) {
+            int num_files = pp.countval("nc_clim_his_file");
+            nc_clim_his_file.resize(num_files);
+            pp.queryarr("nc_clim_his_file", nc_clim_his_file, 0, num_files);
+        }
         pp.queryAdd("nc_clim_coeff_file", nc_clim_coeff_file);
 
         for (int i=0; i<BdyVars::NumTypes; i++) {


### PR DESCRIPTION
Time-series boundary data was already able to be split across multiple NetCDF files. This PR implements the same functionality for NCTimeSeries (climatology and forcing data) and NCTimeSeriesRiver.

Existing functionality should be unaffected.