### PR TITLE
updates constants precision

### DIFF
--- a/Source/REMORA_Constants.H
+++ b/Source/REMORA_Constants.H
@@ -7,14 +7,14 @@ constexpr amrex::Real PI = amrex::Real(3.14159265358979323846264338327950288);
 //Note that amrex source code uses fewer digits of pi:
 //     constexpr Real pi = Real(3.1415926535897932);
 //
-constexpr amrex::Real Cp           = amrex::Real(3985.0);       // Specific heat of seawater [Joules/kg/degC]
-constexpr amrex::Real Csolar       = amrex::Real(1353.0);       // Solar irradiation constant [1360-1380 W/m2]
-constexpr amrex::Real Eradius      = amrex::Real(6371315.0);    // Earth equatorial radius [m]
-constexpr amrex::Real StefBo       = amrex::Real(5.67E-8);      // Stefan-Boltzmann constant [Watts/m2/K4]
-constexpr amrex::Real emmiss       = amrex::Real(0.97);         // Infrared emissivity [non_dimensional]
-constexpr amrex::Real rhow         = amrex::Real(1000.0);       // fresh water density [kg/m3]
-constexpr amrex::Real g            = amrex::Real(9.81);         // acceleration due to gravity [m/s2]
-constexpr amrex::Real vonKar       = amrex::Real(0.41);         // von Karman constant
+constexpr amrex::Real Cp           = amrex::Real(3985.0);              // Specific heat of seawater [Joules/kg/degC]
+constexpr amrex::Real Csolar       = amrex::Real(1353.0);              // Solar irradiation constant [1360-1380 W/m2]
+constexpr amrex::Real Eradius      = amrex::Real(6371315.0);           // Earth equatorial radius [m]
+constexpr amrex::Real StefBo       = amrex::Real(5.670374419e-8);      // Stefan-Boltzmann constant [Watts/m2/K4]
+constexpr amrex::Real emmiss       = amrex::Real(0.97);                // Infrared emissivity [non_dimensional]
+constexpr amrex::Real rhow         = amrex::Real(1000.0);              // fresh water density [kg/m3]
+constexpr amrex::Real g            = amrex::Real(9.80665);             // acceleration due to gravity [m/s2]
+constexpr amrex::Real vonKar       = amrex::Real(0.41);                // von Karman constant
 
 //-----------------------------------------------------------------------
 // Constants used in surface fluxes bulk parameterization.


### PR DESCRIPTION
Increases precision of gravity and Stefan-Boltzmann constants so they are up to NIST CODATA standards. This will prevent egregious energy leaks in future coupled simulations, which we dealt with in E3SM.