### PR TITLE
Enable initialization with averaged-down high-resolution data

### DIFF
--- a/Exec/Advection/prob.H
+++ b/Exec/Advection/prob.H
@@ -18,13 +18,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -33,15 +33,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -50,14 +49,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     ProbParm parms;

--- a/Exec/Advection/prob.cpp
+++ b/Exec/Advection/prob.cpp
@@ -72,8 +72,7 @@ void Problem::init_analytic_prob(
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -91,7 +90,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
@@ -141,15 +139,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=, parms_gpu=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               y_vel(i, j, k) = parms_gpu.v_0;
-        });
-
-        // Construct a box that is on z-faces
-        const Box& zbx = surroundingNodes(bx,2);
-
-        // Set the z-velocity
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/BlankProblem/prob.H
+++ b/Exec/BlankProblem/prob.H
@@ -19,19 +19,19 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_grid_scale (
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_pm, amrex::MultiFab& mf_pn);
+        amrex::MultiFab& mf_pm, amrex::MultiFab& mf_pn) override;
 
     void init_analytic_zeta (
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -40,15 +40,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int lev,
@@ -57,27 +56,27 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_wind(
         int lev,
         const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind);
+        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
     void init_analytic_coriolis (
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_fcor);
+        amrex::MultiFab& mf_fcor) override;
 
 private:
     ProbParm parms;

--- a/Exec/BlankProblem/prob.cpp
+++ b/Exec/BlankProblem/prob.cpp
@@ -61,8 +61,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {}
 
 void Problem::init_analytic_vmix(

--- a/Exec/BoundaryLayer/prob.H
+++ b/Exec/BoundaryLayer/prob.H
@@ -16,19 +16,19 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_grid_scale (
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_pm, amrex::MultiFab& mf_pn);
+        amrex::MultiFab& mf_pm, amrex::MultiFab& mf_pn) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -37,15 +37,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -54,14 +53,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_wind(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind);
+        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind) override;
 
 private:
     [[maybe_unused]] ProbParm parms;

--- a/Exec/BoundaryLayer/prob.cpp
+++ b/Exec/BoundaryLayer/prob.cpp
@@ -111,8 +111,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     [[maybe_unused]] bool l_use_salt = m_solverChoice.use_salt;
     auto T0 = m_solverChoice.T0;
@@ -133,7 +132,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r   = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -149,8 +147,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             x_vel(i, j, k) = 0.0_rt;
@@ -158,11 +154,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/Channel_Test/prob.H
+++ b/Exec/Channel_Test/prob.H
@@ -16,13 +16,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -31,15 +31,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -48,14 +47,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 private:
     [[maybe_unused]] ProbParm parms;
 };

--- a/Exec/Channel_Test/prob.cpp
+++ b/Exec/Channel_Test/prob.cpp
@@ -74,8 +74,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -95,7 +94,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -125,8 +123,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(grow(grow(xbx,1,1),0,1), [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // Create bounding box for x and y to make spatially-dependent T and S
@@ -151,11 +147,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/CoupleToERF/prob.H
+++ b/Exec/CoupleToERF/prob.H
@@ -19,7 +19,7 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -28,15 +28,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_wind(
         int lev,
         const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind);
+        amrex::MultiFab& mf_Uwind, amrex::MultiFab& mf_Vwind) override;
 
 private:
 //    ProbParm parms;

--- a/Exec/CoupleToERF/prob.cpp
+++ b/Exec/CoupleToERF/prob.cpp
@@ -46,8 +46,7 @@ void Problem::init_analytic_prob(
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     auto T0 = m_solverChoice.T0;
     auto S0 = m_solverChoice.S0;
@@ -57,7 +56,6 @@ void Problem::init_analytic_prob(
     mf_cons.setVal(0.0_rt,Tracer_comp,1);
     mf_xvel.setVal(0.0_rt);
     mf_yvel.setVal(0.0_rt);
-    mf_zvel.setVal(0.0_rt);
 }
 
 void Problem::init_analytic_wind(

--- a/Exec/Dogbone/prob.H
+++ b/Exec/Dogbone/prob.H
@@ -18,7 +18,7 @@ public:
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -27,14 +27,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 private:
     ProbParm parms;
 };

--- a/Exec/DogboneAnalytic/prob.H
+++ b/Exec/DogboneAnalytic/prob.H
@@ -17,13 +17,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -32,8 +32,7 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
 
     void init_analytic_vmix(
@@ -41,7 +40,7 @@ public:
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -50,21 +49,21 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
     void init_analytic_masks(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_mskr);
+        amrex::MultiFab& mf_mskr) override;
 private:
     ProbParm parms;
 };

--- a/Exec/DogboneAnalytic/prob.cpp
+++ b/Exec/DogboneAnalytic/prob.cpp
@@ -85,8 +85,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -100,7 +99,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& x_r = remora.vec_xr[lev]->const_array(mfi);
         if (parms.traditional) {
@@ -133,8 +131,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             x_vel(i, j, k) = 0.0_rt;
@@ -142,11 +138,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/DoubleGyre/prob.H
+++ b/Exec/DoubleGyre/prob.H
@@ -16,13 +16,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -31,15 +31,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -48,14 +47,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 private:
     [[maybe_unused]] ProbParm parms;
 };

--- a/Exec/DoubleGyre/prob.cpp
+++ b/Exec/DoubleGyre/prob.cpp
@@ -50,8 +50,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -70,7 +69,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -98,8 +96,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             x_vel(i,j,k) = 0.0_rt;
@@ -107,11 +103,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/DoublyPeriodic/prob.H
+++ b/Exec/DoublyPeriodic/prob.H
@@ -23,13 +23,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -38,15 +38,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -55,14 +54,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     ProbParm parms;

--- a/Exec/DoublyPeriodic/prob.cpp
+++ b/Exec/DoublyPeriodic/prob.cpp
@@ -117,8 +117,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -135,7 +134,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -197,15 +195,6 @@ void Problem::init_analytic_prob(
               // const Real x = prob_lo[0] + (i + 0.5) * dx[0];
               // const Real y = prob_lo[1] + (j + 0.5) * dx[1];
               y_vel(i, j, k) = parms_gpu.v_0;
-        });
-
-        // Construct a box that is on z-faces
-        const Box& zbx = surroundingNodes(bx,2);
-
-        // Set the z-velocity
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/IdealMiniGrid/prob.H
+++ b/Exec/IdealMiniGrid/prob.H
@@ -18,7 +18,7 @@ public:
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -27,14 +27,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     [[maybe_unused]] ProbParm parms;

--- a/Exec/IdealRivGrid/prob.H
+++ b/Exec/IdealRivGrid/prob.H
@@ -18,7 +18,7 @@ public:
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -27,14 +27,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     ProbParm parms;

--- a/Exec/ParticlesOverSeaMount/prob.H
+++ b/Exec/ParticlesOverSeaMount/prob.H
@@ -23,13 +23,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -38,15 +38,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -55,14 +54,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     ProbParm parms;

--- a/Exec/ParticlesOverSeaMount/prob.cpp
+++ b/Exec/ParticlesOverSeaMount/prob.cpp
@@ -111,8 +111,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     auto geomdata = geom.data();
     const int khi = geomdata.Domain().bigEnd()[2];
@@ -127,7 +126,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -185,15 +183,6 @@ void Problem::init_analytic_prob(
               // const Real x = prob_lo[0] + (i + 0.5) * dx[0];
               // const Real y = prob_lo[1] + (j + 0.5) * dx[1];
               y_vel(i, j, k) = 0.0_rt;
-        });
-
-        // Construct a box that is on z-faces
-        const Box& zbx = surroundingNodes(bx,2);
-
-        // Set the z-velocity
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/Seamount/prob.H
+++ b/Exec/Seamount/prob.H
@@ -17,13 +17,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -32,15 +32,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -49,14 +48,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     [[maybe_unused]] ProbParm parms;

--- a/Exec/Seamount/prob.cpp
+++ b/Exec/Seamount/prob.cpp
@@ -90,8 +90,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -108,7 +107,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -149,15 +147,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
               y_vel(i, j, k) = 0.0;
-        });
-
-        // Construct a box that is on z-faces
-        const Box& zbx = surroundingNodes(bx,2);
-
-        // Set the z-velocity
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/Upwelling/GNUmakefile
+++ b/Exec/Upwelling/GNUmakefile
@@ -18,7 +18,6 @@ USE_HIP   = FALSE
 USE_SYCL  = FALSE
 
 # Debugging
-DEBUG = TRUE
 DEBUG = FALSE
 
 TEST = TRUE

--- a/Exec/Upwelling/inputs
+++ b/Exec/Upwelling/inputs
@@ -1,7 +1,9 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-remora.max_step = 10
+remora.max_step = 100
 
-remora.omp_tile_size = 1024 1024 1024
+remora.omp_tile_size = 16 16 1024
+
+amrex.fpe_trap_invalid=1
 
 # PROBLEM SIZE & GEOMETRY
 remora.prob_lo     =      0.     0.    -150.
@@ -15,9 +17,9 @@ remora.bc.ylo.type = "SlipWall"
 remora.bc.yhi.type = "SlipWall"
 
 # TIME STEP CONTROL
-remora.fixed_dt       = 300.0 # Timestep size (seconds)
+remora.fixed_dt       = 90.0 # Timestep size (seconds)
 
-remora.fixed_fast_dt  = 10.0 # Baratropic timestep size (seconds)
+remora.fixed_fast_dt  = 3.0 # Baratropic timestep size (seconds)
 
 #remora.fixed_ndtfast_ratio  = 30 # Ratio of baroclinic to barotropic time step
 
@@ -31,13 +33,14 @@ remora.check_int       = -57600      # number of timesteps between checkpoints
 
 # PLOTFILES
 remora.plot_file     = plt        # prefix of plotfile name
-remora.plot_int      = 100        # number of timesteps between plotfiles
+remora.plot_int      = 1000        # number of timesteps between plotfiles
 remora.plot_vars_3d  = salt temp x_velocity y_velocity z_velocity
 remora.plotfile_type = amrex
 
 # SOLVER CHOICE
 remora.flat_bathymetry = false
 remora.tracer_horizontal_advection_scheme = "upstream3" # upstream3 or centered4
+remora.harmonic_mixing_type = "geopotential"
 
 # Linear EOS parameters
 remora.R0    = 1027.0  # background density value (Kg/m3) used in Linear Equation of State
@@ -55,3 +58,14 @@ remora.coriolis_type = beta_plane
 remora.coriolis_f0 = -8.26e-5
 remora.coriolis_beta = 0.0
 
+amr.max_level=1
+amr.ref_ratio_vect=3 3 1
+remora.hires_grid_level=1
+
+remora.expand_plotvars_to_unif_rr=1
+
+remora.refinement_indicators=box
+remora.box.max_level=1
+remora.box.in_box_lo=-10000 -5000 -150
+remora.box.in_box_hi=20000 20000 0
+remora.coupling_type="TwoWay"

--- a/Exec/Upwelling/prob.H
+++ b/Exec/Upwelling/prob.H
@@ -16,13 +16,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -31,15 +31,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -48,14 +47,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     [[maybe_unused]] ProbParm parms;

--- a/Exec/Upwelling/prob.cpp
+++ b/Exec/Upwelling/prob.cpp
@@ -102,8 +102,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -123,7 +122,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -143,8 +141,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             x_vel(i, j, k) = 0.0_rt;
@@ -152,11 +148,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Exec/Upwelling_ML/prob.H
+++ b/Exec/Upwelling_ML/prob.H
@@ -23,13 +23,13 @@ public:
         int lev, const amrex::Geometry& geom,
         SolverChoice const& m_solverChoice,
         REMORA const& remora,
-        amrex::MultiFab& mf_h);
+        amrex::MultiFab& mf_h) override;
 
     void init_analytic_zeta (
         int /*lev*/, const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& /*remora*/,
-        amrex::MultiFab& mf_zeta);
+        amrex::MultiFab& mf_zeta) override;
 
     void init_analytic_prob(
         int lev,
@@ -38,15 +38,14 @@ public:
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel);
+        amrex::MultiFab& mf_yvel) override;
 
     void init_analytic_vmix(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt);
+        amrex::MultiFab& mf_Akv, amrex::MultiFab& mf_Akt) override;
 
     void init_analytic_hmix(
         int /*lev*/,
@@ -55,14 +54,14 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& mf_visc2_p,
         amrex::MultiFab& mf_visc2_r,
-        amrex::MultiFab& mf_diff2);
+        amrex::MultiFab& mf_diff2) override;
 
     void init_analytic_smflux(
         int lev,
         const amrex::Geometry& /*geom*/,
         SolverChoice const& /*m_solverChoice*/,
         REMORA const& remora,
-        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr);
+        amrex::MultiFab& mf_sustr, amrex::MultiFab& mf_svstr) override;
 
 private:
     ProbParm parms;

--- a/Exec/Upwelling_ML/prob.cpp
+++ b/Exec/Upwelling_ML/prob.cpp
@@ -163,8 +163,7 @@ void Problem::init_analytic_prob(
         REMORA const& remora,
         amrex::MultiFab& mf_cons,
         amrex::MultiFab& mf_xvel,
-        amrex::MultiFab& mf_yvel,
-        amrex::MultiFab& mf_zvel)
+        amrex::MultiFab& mf_yvel)
 {
     bool l_use_salt = m_solverChoice.use_salt;
 
@@ -184,7 +183,6 @@ void Problem::init_analytic_prob(
         Array4<      Real> const& state = mf_cons.array(mfi);
         Array4<      Real> const& x_vel = mf_xvel.array(mfi);
         Array4<      Real> const& y_vel = mf_yvel.array(mfi);
-        Array4<      Real> const& z_vel = mf_zvel.array(mfi);
 
         Array4<const Real> const& z_r = remora.vec_z_r[lev]->const_array(mfi);
 
@@ -217,8 +215,6 @@ void Problem::init_analytic_prob(
 
         const Box& xbx = surroundingNodes(bx,0);
         const Box& ybx = surroundingNodes(bx,1);
-        const Box& zbx = surroundingNodes(bx,2);
-
         ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
       //      x_vel(i, j, k) = 0.0_rt;
@@ -230,11 +226,6 @@ void Problem::init_analytic_prob(
         ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             y_vel(i, j, k) = 0.0_rt;
-        });
-
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            z_vel(i, j, k) = 0.0_rt;
         });
     }
     Gpu::streamSynchronize();

--- a/Source/IO/REMORA_ReadFromInitNetcdf.cpp
+++ b/Source/IO/REMORA_ReadFromInitNetcdf.cpp
@@ -40,6 +40,39 @@ read_data_from_netcdf (int /*lev*/,
  * @param lev             level of data to read
  * @param domain          simulation domain
  * @param fname           file name to read from
+ * @param NC_temp_fab     container for temperature data
+ * @param NC_salt_fab     container for salinity data
+ * @param NC_u_fab        container for u velocity data
+ * @param NC_v_fab        container for v velocity data
+ * @param ngrow           number of grow cells to read
+ */
+void
+read_data_full_domain_from_netcdf (int /*lev*/,
+                       const Box& domain,
+                       const std::string& fname,
+                       FArrayBox& NC_temp_fab, FArrayBox& NC_salt_fab,
+                       FArrayBox& NC_xvel_fab, FArrayBox& NC_yvel_fab,
+                       IntVect ngrow)
+{
+    amrex::Print() << "Loading initial solution data from NetCDF file " << fname << std::endl;
+
+    Vector<FArrayBox*> NC_fabs;
+    Vector<std::string> NC_names;
+    Vector<enum NC_Data_Dims_Type> NC_dim_types;
+
+    NC_fabs.push_back(&NC_temp_fab); NC_names.push_back("temp");     NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE); // 0
+    NC_fabs.push_back(&NC_salt_fab); NC_names.push_back("salt");     NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE); // 1
+    NC_fabs.push_back(&NC_xvel_fab); NC_names.push_back("u");        NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE); // 2
+    NC_fabs.push_back(&NC_yvel_fab); NC_names.push_back("v");        NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE); // 3
+
+    // Read the netcdf file and fill these FABs
+    BuildFABsFromNetCDFFile<FArrayBox,Real>(domain, fname, NC_names, NC_dim_types, NC_fabs, false, 0, ngrow);
+}
+
+/**
+ * @param lev             level of data to read
+ * @param domain          simulation domain
+ * @param fname           file name to read from
  * @param NC_zeta_fab     container for sea surface height data
  */
 void
@@ -58,6 +91,32 @@ read_zeta_from_netcdf (int /*lev*/,
 
     // Read the netcdf file and fill these FABs
     BuildFABsFromNetCDFFile<FArrayBox,Real>(domain, fname, NC_names, NC_dim_types, NC_fabs);
+}
+
+/**
+ * @param lev             level of data to read
+ * @param domain          simulation domain
+ * @param fname           file name to read from
+ * @param NC_zeta_fab     container for sea surface height data
+ * @param ngrow           number of grow cells to read in, if not default
+ */
+void
+read_zeta_full_domain_from_netcdf (int /*lev*/,
+                      const Box& domain,
+                      const std::string& fname,
+                      FArrayBox& NC_zeta_fab,
+                      IntVect ngrow)
+{
+    amrex::Print() << "Loading initial sea surface height from NetCDF file " << fname << std::endl;
+
+    Vector<FArrayBox*> NC_fabs;
+    Vector<std::string> NC_names;
+    Vector<enum NC_Data_Dims_Type> NC_dim_types;
+
+    NC_fabs.push_back(&NC_zeta_fab )   ; NC_names.push_back("zeta")    ; NC_dim_types.push_back(NC_Data_Dims_Type::Time_SN_WE); // 0
+
+    // Read the netcdf file and fill these FABs
+    BuildFABsFromNetCDFFile<FArrayBox,Real>(domain, fname, NC_names, NC_dim_types, NC_fabs, false, 0, ngrow);
 }
 
 /**

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -271,7 +271,6 @@ void REMORA::allocate_init_full_domain () {
     Box refined_domain = geom[0].Domain();
 
     DistributionMapping dm(ba);
-    Print() << "making full domain with " << ncons << " components" << std::endl;
     vec_cons_full_domain[0].reset(new MultiFab(ba, dm, ncons, IntVect(1,1,0)));
     vec_xvel_full_domain[0].reset(new MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, IntVect(0,1,0)));
     vec_yvel_full_domain[0].reset(new MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, IntVect(1,0,0)));
@@ -282,8 +281,9 @@ void REMORA::allocate_init_full_domain () {
     auto xvel_growvect = xvel_new[0]->nGrowVect();
     auto yvel_growvect = yvel_new[0]->nGrowVect();
     auto zeta_growvect = vec_zeta[0]->nGrowVect();
-    for (int lev=1; lev <= hires_grid_level; lev++) {
+    for (int lev=1; lev <= hires_init_level; lev++) {
         ba = ba.refine(refRatio(lev-1));
+        ba2d = ba2d.refine(refRatio(lev-1));
         refined_domain.refine(refRatio(lev-1));
 
         // Always allocate at least as many grow cells as there are in the level's normal variable multifab

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -14,9 +14,17 @@ using namespace amrex;
 void
 REMORA::init_analytic(int lev)
 {
-    prob->init_analytic_prob(lev, geom[lev], solverChoice, *this, *cons_new[lev], *xvel_new[lev], *yvel_new[lev], *zvel_new[lev]);
+    prob->init_analytic_prob(lev, geom[lev], solverChoice, *this, *cons_new[lev], *xvel_new[lev], *yvel_new[lev]);
 
     set_grid_scale(lev);
+}
+
+void
+REMORA::init_full_domain_analytic()
+{
+    prob->init_analytic_prob(hires_init_level, geom[hires_init_level], solverChoice, *this, *vec_cons_full_domain[hires_init_level], *vec_xvel_full_domain[hires_init_level], *vec_yvel_full_domain[hires_init_level]);
+
+    set_grid_scale(hires_init_level);
 }
 
 /**
@@ -220,8 +228,6 @@ void REMORA::allocate_bathymetry_grid_vars_full_domain () {
     BoxArray ba;
     ba.define(makeSlab(geom[0].Domain(),2,0));
     Box refined_domain = makeSlab(geom[0].Domain(),2,0);
-    IntVect cum_ref_ratio = IntVect(1,1,0); // cumulative refinement ratio
-    cum_ref_ratios.push_back(cum_ref_ratio);
 
     DistributionMapping dm(ba);
     vec_h_full_domain[0].reset(new MultiFab(ba, dm, 1, IntVect(1,1,0)));
@@ -234,16 +240,12 @@ void REMORA::allocate_bathymetry_grid_vars_full_domain () {
     for (int lev=1; lev <= hires_grid_level; lev++) {
         ba = ba.refine(refRatio(lev-1));
         refined_domain.refine(refRatio(lev-1));
-        // Calculate the cumulative refinement ratio from level lev to level 0
-        cum_ref_ratio[0] = cum_ref_ratio[0] * refRatio(lev-1)[0];
-        cum_ref_ratio[1] = cum_ref_ratio[1] * refRatio(lev-1)[1];
-        cum_ref_ratios.push_back(cum_ref_ratio);
 
         // Always allocate at least as many grow cells as there are in the level's normal variable multifab
         // This makes copying and boundary filling much easier
-        vec_h_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratio,h_growvect)));
-        vec_pm_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratio,pm_growvect)));
-        vec_pn_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratio,pn_growvect)));
+        vec_h_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],h_growvect)));
+        vec_pm_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],pm_growvect)));
+        vec_pn_full_domain[lev].reset(new MultiFab(ba, dm, 1, max(cum_ref_ratios[lev],pn_growvect)));
     }
     nc_hires_grid_box = refined_domain;
 }
@@ -258,4 +260,38 @@ REMORA::init_bathymetry_full_domain_from_analytic ()
     for (int lev=hires_grid_level-1; lev >= 0; lev--) {
         average_down_with_grow_cells(lev, vec_h_full_domain);
     }
+}
+
+void REMORA::allocate_init_full_domain () {
+    // Make fake boxArray that covers the whole domain on level 0
+    BoxArray ba;
+    ba.define(geom[0].Domain());
+    BoxArray ba2d;
+    ba2d.define(makeSlab(geom[0].Domain(),2,0));
+    Box refined_domain = geom[0].Domain();
+
+    DistributionMapping dm(ba);
+    Print() << "making full domain with " << ncons << " components" << std::endl;
+    vec_cons_full_domain[0].reset(new MultiFab(ba, dm, ncons, IntVect(1,1,0)));
+    vec_xvel_full_domain[0].reset(new MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, IntVect(0,1,0)));
+    vec_yvel_full_domain[0].reset(new MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, IntVect(1,0,0)));
+    vec_zeta_full_domain[0].reset(new MultiFab(ba2d, dm, 1, IntVect(1,1,0)));
+
+
+    auto cons_growvect = cons_new[0]->nGrowVect();
+    auto xvel_growvect = xvel_new[0]->nGrowVect();
+    auto yvel_growvect = yvel_new[0]->nGrowVect();
+    auto zeta_growvect = vec_zeta[0]->nGrowVect();
+    for (int lev=1; lev <= hires_grid_level; lev++) {
+        ba = ba.refine(refRatio(lev-1));
+        refined_domain.refine(refRatio(lev-1));
+
+        // Always allocate at least as many grow cells as there are in the level's normal variable multifab
+        // This makes copying and boundary filling much easier
+        vec_cons_full_domain[lev].reset(new MultiFab(ba, dm, ncons, max(cum_ref_ratios[lev],cons_growvect)));
+        vec_xvel_full_domain[lev].reset(new MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, max(cum_ref_ratios[lev],xvel_growvect) - IntVect(1,0,0)));
+        vec_yvel_full_domain[lev].reset(new MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, max(cum_ref_ratios[lev],yvel_growvect) - IntVect(0,1,0)));
+        vec_zeta_full_domain[lev].reset(new MultiFab(ba2d, dm, 1, max(cum_ref_ratios[lev],zeta_growvect)));
+    }
+    nc_hires_init_box = refined_domain;
 }

--- a/Source/Initialization/REMORA_init.cpp
+++ b/Source/Initialization/REMORA_init.cpp
@@ -19,14 +19,6 @@ REMORA::init_analytic(int lev)
     set_grid_scale(lev);
 }
 
-void
-REMORA::init_full_domain_analytic()
-{
-    prob->init_analytic_prob(hires_init_level, geom[hires_init_level], solverChoice, *this, *vec_cons_full_domain[hires_init_level], *vec_xvel_full_domain[hires_init_level], *vec_yvel_full_domain[hires_init_level]);
-
-    set_grid_scale(hires_init_level);
-}
-
 /**
  * @param[in   ] lev     level to initialize on
  */
@@ -294,4 +286,26 @@ void REMORA::allocate_init_full_domain () {
         vec_zeta_full_domain[lev].reset(new MultiFab(ba2d, dm, 1, max(cum_ref_ratios[lev],zeta_growvect)));
     }
     nc_hires_init_box = refined_domain;
+}
+
+void
+REMORA::init_full_domain_from_analytic ()
+{
+    prob->init_analytic_prob(hires_init_level, geom[hires_init_level], solverChoice, *this, *vec_cons_full_domain[hires_init_level], *vec_xvel_full_domain[hires_init_level], *vec_yvel_full_domain[hires_init_level]);
+
+    for (int lev=hires_init_level-1; lev >= 0; lev--) {
+        average_down_with_grow_cells(lev, vec_cons_full_domain);
+        average_down_with_grow_cells(lev, vec_xvel_full_domain);
+        average_down_with_grow_cells(lev, vec_yvel_full_domain);
+    }
+}
+
+void
+REMORA::init_full_domain_zeta_from_analytic ()
+{
+    prob->init_analytic_zeta(hires_init_level, geom[hires_init_level], solverChoice, *this, *vec_zeta_full_domain[hires_init_level]);
+
+    for (int lev=hires_init_level-1; lev >= 0; lev--) {
+        average_down_with_grow_cells(lev, vec_zeta_full_domain);
+    }
 }

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -17,6 +17,13 @@ read_data_from_netcdf (int /*lev*/, const Box& domain, const std::string& fname,
                        FArrayBox& NC_temp_fab, FArrayBox& NC_salt_fab,
                        FArrayBox& NC_xvel_fab, FArrayBox& NC_yvel_fab);
 
+/** \brief helper function for reading in full domain high-resolution initial state data from netcdf */
+void
+read_data_full_domain_from_netcdf (int /*lev*/, const Box& domain, const std::string& fname,
+                       FArrayBox& NC_temp_fab, FArrayBox& NC_salt_fab,
+                       FArrayBox& NC_xvel_fab, FArrayBox& NC_yvel_fab,
+                       IntVect ngrow);
+
 /** \brief helper function for reading in land-sea masks from netcdf */
 void
 read_masks_from_netcdf (int /*lev*/, const Box& domain, const std::string& fname,
@@ -77,6 +84,11 @@ read_coriolis_from_netcdf (int lev, const Box& domain, const std::string& fname,
 void
 read_zeta_from_netcdf (int lev, const Box& domain, const std::string& fname,
                              FArrayBox& NC_zeta_fab);
+
+/** \brief helper function to read high-resolution full-domain sea surface height from netcdf */
+void
+read_zeta_full_domain_from_netcdf (int lev, const Box& domain, const std::string& fname,
+                                   FArrayBox& NC_zeta_fab, IntVect ngrow);
 
 /** \brief helper function to read climatology nudging from netcdf */
 void
@@ -150,16 +162,13 @@ REMORA::init_data_full_domain_from_netcdf ()
     Vector<FArrayBox> NC_xvel_fab ; NC_xvel_fab.resize(1);
     Vector<FArrayBox> NC_yvel_fab ; NC_yvel_fab.resize(1);
 
-    read_data_from_netcdf(hires_init_level, nc_hires_init_box, nc_init_file_hires,
+    read_data_full_domain_from_netcdf(hires_init_level, nc_hires_init_box, nc_init_file_hires,
                           NC_temp_fab[0], NC_salt_fab[0],
-                          NC_xvel_fab[0], NC_yvel_fab[0]);
+                          NC_xvel_fab[0], NC_yvel_fab[0],
+                          cum_ref_ratios[hires_init_level]);
 
-
-    Print() << "before alias temp " << Temp_comp << " " << vec_cons_full_domain[hires_init_level]->nComp() << std::endl;
     MultiFab mf_temp(*vec_cons_full_domain[hires_init_level], make_alias, Temp_comp, 1);
-    Print() << "before alias salt " << Salt_comp << std::endl;
     MultiFab mf_salt(*vec_cons_full_domain[hires_init_level], make_alias, Salt_comp, 1);
-    Print() << "after alias" << std::endl;
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -168,14 +177,12 @@ REMORA::init_data_full_domain_from_netcdf ()
     // Don't tile this since we are operating on full FABs in this routine
     for ( MFIter mfi(mf_temp, false); mfi.isValid(); ++mfi )
     {
-        Print() << "in mfiter" << std::endl;
         // Define fabs for holding the initial data
         FArrayBox &temp_fab = mf_temp[mfi];
         FArrayBox &salt_fab = mf_salt[mfi];
         FArrayBox &xvel_fab = (*vec_xvel_full_domain[hires_init_level])[mfi];
         FArrayBox &yvel_fab = (*vec_yvel_full_domain[hires_init_level])[mfi];
 
-        Print() << "in init state" << std::endl;
         init_state_from_netcdf(hires_init_level, temp_fab, salt_fab,
                                xvel_fab, yvel_fab,
                                NC_temp_fab, NC_salt_fab,
@@ -187,20 +194,13 @@ REMORA::init_data_full_domain_from_netcdf ()
     if (nscalar > 1) {
         vec_cons_full_domain[hires_init_level]->setVal(0.0_rt, Tracer_comp + 1, nscalar - 1, vec_cons_full_domain[hires_init_level]->nGrowVect());
     }
-    print_state(*vec_cons_full_domain[hires_init_level],IntVect(10,10,0));
 
     // Average down to fill levels below hires_grid_level. Use a special average_down so
     // grow cells get populated by averaged down fine data
-    for (int lev=hires_grid_level-1; lev >= 0; lev--) {
-        Print() << "ad cons" << std::endl;
-        average_down_with_grow_cells(lev, vec_cons_full_domain);;
-        Print() << "ad xvel" << std::endl;
-        average_down_with_grow_cells(lev, vec_xvel_full_domain);;
-        Print() << "ad yvel" << std::endl;
-        average_down_with_grow_cells(lev, vec_yvel_full_domain);;
-        Print() << "ad zeta" << std::endl;
-        average_down_with_grow_cells(lev, vec_zeta_full_domain);;
-        Print() << "ad done" << std::endl;
+    for (int lev=hires_init_level-1; lev >= 0; lev--) {
+        average_down_with_grow_cells(lev, vec_cons_full_domain);
+        average_down_with_grow_cells(lev, vec_xvel_full_domain);
+        average_down_with_grow_cells(lev, vec_yvel_full_domain);
     }
 }
 
@@ -254,6 +254,41 @@ REMORA::init_zeta_from_netcdf (int lev)
 //    fill_from_bdyfiles(lev, *vec_zeta[lev], *vec_mskr[lev], told, BCVars::zeta_bc,BdyVars::zeta,1,1);
 //    fill_from_bdyfiles(lev, *vec_zeta[lev], *vec_mskr[lev], told, BCVars::zeta_bc,BdyVars::zeta,2,2);
 }
+
+void
+REMORA::init_zeta_full_domain_from_netcdf ()
+{
+    // *** FArrayBox's at this level for holding the INITIAL data
+    Vector<FArrayBox> NC_zeta_fab     ; NC_zeta_fab.resize(1);
+
+    read_zeta_full_domain_from_netcdf(hires_init_level, nc_hires_init_box, nc_init_file_hires,
+                          NC_zeta_fab[0], cum_ref_ratios[hires_init_level]);
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        {
+        // Don't tile this since we are operating on full FABs in this routine
+        for ( MFIter mfi(*vec_zeta_full_domain[hires_init_level], false); mfi.isValid(); ++mfi )
+        {
+            FArrayBox &zeta_fab  = (*vec_zeta_full_domain[hires_init_level])[mfi];
+
+            //
+            // FArrayBox to FArrayBox copy does "copy on intersection"
+            // This only works here because we have broadcast the FArrayBox of data from the netcdf file to all ranks
+            //
+
+            zeta_fab.template    copy<RunOn::Device>(NC_zeta_fab[0],0,0,1);
+        } // mf
+        } // omp
+
+    // Average down to fill levels below hires_grid_level. Use a special average_down so
+    // grow cells get populated by averaged down fine data
+    for (int lev=hires_init_level-1; lev >= 0; lev--) {
+        average_down_with_grow_cells(lev, vec_zeta_full_domain);
+    }
+}
+
 
 /**
  * @param lev Integer specifying the current level
@@ -567,7 +602,7 @@ REMORA::init_bdry_from_netcdf (int lev)
 }
 
 /**
- * \brief Helper function to initialize state and velocity data in a Fab from a REMORAdataset.
+ * \brief Helper function to initialize state and velocity data in a Fab.
  *
  * @param lev Integer specifying current level
  * @param state_fab FArrayBox object holding the state data we initialize
@@ -588,6 +623,44 @@ init_state_from_netcdf (int /*lev*/,
                         const Vector<FArrayBox>& NC_salt_fab,
                         const Vector<FArrayBox>& NC_xvel_fab,
                         const Vector<FArrayBox>& NC_yvel_fab)
+{
+    int nboxes = NC_xvel_fab.size();
+    for (int idx = 0; idx < nboxes; idx++)
+    {
+        //
+        // FArrayBox to FArrayBox copy does "copy on intersection"
+        // This only works here because we have broadcast the FArrayBox of data from the netcdf file to all ranks
+        //
+        temp_fab.template copy<RunOn::Device>(NC_temp_fab[idx]);
+        salt_fab.template copy<RunOn::Device>(NC_salt_fab[idx]);
+        x_vel_fab.template copy<RunOn::Device>(NC_xvel_fab[idx]);
+        y_vel_fab.template copy<RunOn::Device>(NC_yvel_fab[idx]);
+    } // idx
+}
+
+/**
+ * \brief Helper function to initialize state and velocity data in a Fab.
+ *
+ * @param lev Integer specifying current level
+ * @param state_fab FArrayBox object holding the state data we initialize
+ * @param temp_fab  FArrayBox object holding the temperature data we initialize
+ * @param salt_fab  FArrayBox object holding the salt        data we initialize
+ * @param x_vel_fab FArrayBox object holding the x-velocity data we initialize
+ * @param y_vel_fab FArrayBox object holding the y-velocity data we initialize
+ * @param NC_temp_fab Vector of FArrayBox objects with the REMORA dataset specifying temperature
+ * @param NC_salt_fab Vector of FArrayBox objects with the REMORA dataset specifying salinity
+ * @param NC_xvel_fab Vector of FArrayBox objects with the REMORA dataset specifying x-velocity
+ * @param NC_yvel_fab Vector of FArrayBox objects with the REMORA dataset specifying y-velocity
+ */
+void
+init_state_full_domain_from_netcdf (int /*lev*/,
+                        FArrayBox&  temp_fab, FArrayBox&  salt_fab,
+                        FArrayBox& x_vel_fab, FArrayBox& y_vel_fab,
+                        const Vector<FArrayBox>& NC_temp_fab,
+                        const Vector<FArrayBox>& NC_salt_fab,
+                        const Vector<FArrayBox>& NC_xvel_fab,
+                        const Vector<FArrayBox>& NC_yvel_fab,
+                        IntVect ngrow)
 {
     int nboxes = NC_xvel_fab.size();
     for (int idx = 0; idx < nboxes; idx++)

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -639,44 +639,6 @@ init_state_from_netcdf (int /*lev*/,
 }
 
 /**
- * \brief Helper function to initialize state and velocity data in a Fab.
- *
- * @param lev Integer specifying current level
- * @param state_fab FArrayBox object holding the state data we initialize
- * @param temp_fab  FArrayBox object holding the temperature data we initialize
- * @param salt_fab  FArrayBox object holding the salt        data we initialize
- * @param x_vel_fab FArrayBox object holding the x-velocity data we initialize
- * @param y_vel_fab FArrayBox object holding the y-velocity data we initialize
- * @param NC_temp_fab Vector of FArrayBox objects with the REMORA dataset specifying temperature
- * @param NC_salt_fab Vector of FArrayBox objects with the REMORA dataset specifying salinity
- * @param NC_xvel_fab Vector of FArrayBox objects with the REMORA dataset specifying x-velocity
- * @param NC_yvel_fab Vector of FArrayBox objects with the REMORA dataset specifying y-velocity
- */
-void
-init_state_full_domain_from_netcdf (int /*lev*/,
-                        FArrayBox&  temp_fab, FArrayBox&  salt_fab,
-                        FArrayBox& x_vel_fab, FArrayBox& y_vel_fab,
-                        const Vector<FArrayBox>& NC_temp_fab,
-                        const Vector<FArrayBox>& NC_salt_fab,
-                        const Vector<FArrayBox>& NC_xvel_fab,
-                        const Vector<FArrayBox>& NC_yvel_fab,
-                        IntVect ngrow)
-{
-    int nboxes = NC_xvel_fab.size();
-    for (int idx = 0; idx < nboxes; idx++)
-    {
-        //
-        // FArrayBox to FArrayBox copy does "copy on intersection"
-        // This only works here because we have broadcast the FArrayBox of data from the netcdf file to all ranks
-        //
-        temp_fab.template copy<RunOn::Device>(NC_temp_fab[idx]);
-        salt_fab.template copy<RunOn::Device>(NC_salt_fab[idx]);
-        x_vel_fab.template copy<RunOn::Device>(NC_xvel_fab[idx]);
-        y_vel_fab.template copy<RunOn::Device>(NC_yvel_fab[idx]);
-    } // idx
-}
-
-/**
  * @param lev Integer specifying the current level
  */
 void

--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -141,6 +141,69 @@ REMORA::init_data_from_netcdf (int lev)
     }
 }
 
+void
+REMORA::init_data_full_domain_from_netcdf ()
+{
+    // *** FArrayBox's at this level for holding the INITIAL data
+    Vector<FArrayBox> NC_temp_fab ; NC_temp_fab.resize(1);
+    Vector<FArrayBox> NC_salt_fab ; NC_salt_fab.resize(1);
+    Vector<FArrayBox> NC_xvel_fab ; NC_xvel_fab.resize(1);
+    Vector<FArrayBox> NC_yvel_fab ; NC_yvel_fab.resize(1);
+
+    read_data_from_netcdf(hires_init_level, nc_hires_init_box, nc_init_file_hires,
+                          NC_temp_fab[0], NC_salt_fab[0],
+                          NC_xvel_fab[0], NC_yvel_fab[0]);
+
+
+    Print() << "before alias temp " << Temp_comp << " " << vec_cons_full_domain[hires_init_level]->nComp() << std::endl;
+    MultiFab mf_temp(*vec_cons_full_domain[hires_init_level], make_alias, Temp_comp, 1);
+    Print() << "before alias salt " << Salt_comp << std::endl;
+    MultiFab mf_salt(*vec_cons_full_domain[hires_init_level], make_alias, Salt_comp, 1);
+    Print() << "after alias" << std::endl;
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    {
+    // Don't tile this since we are operating on full FABs in this routine
+    for ( MFIter mfi(mf_temp, false); mfi.isValid(); ++mfi )
+    {
+        Print() << "in mfiter" << std::endl;
+        // Define fabs for holding the initial data
+        FArrayBox &temp_fab = mf_temp[mfi];
+        FArrayBox &salt_fab = mf_salt[mfi];
+        FArrayBox &xvel_fab = (*vec_xvel_full_domain[hires_init_level])[mfi];
+        FArrayBox &yvel_fab = (*vec_yvel_full_domain[hires_init_level])[mfi];
+
+        Print() << "in init state" << std::endl;
+        init_state_from_netcdf(hires_init_level, temp_fab, salt_fab,
+                               xvel_fab, yvel_fab,
+                               NC_temp_fab, NC_salt_fab,
+                               NC_xvel_fab, NC_yvel_fab);
+    } // mf
+    } // omp
+
+    vec_cons_full_domain[hires_init_level]->setVal(0.0_rt, Tracer_comp, 1, vec_cons_full_domain[hires_init_level]->nGrowVect());
+    if (nscalar > 1) {
+        vec_cons_full_domain[hires_init_level]->setVal(0.0_rt, Tracer_comp + 1, nscalar - 1, vec_cons_full_domain[hires_init_level]->nGrowVect());
+    }
+    print_state(*vec_cons_full_domain[hires_init_level],IntVect(10,10,0));
+
+    // Average down to fill levels below hires_grid_level. Use a special average_down so
+    // grow cells get populated by averaged down fine data
+    for (int lev=hires_grid_level-1; lev >= 0; lev--) {
+        Print() << "ad cons" << std::endl;
+        average_down_with_grow_cells(lev, vec_cons_full_domain);;
+        Print() << "ad xvel" << std::endl;
+        average_down_with_grow_cells(lev, vec_xvel_full_domain);;
+        Print() << "ad yvel" << std::endl;
+        average_down_with_grow_cells(lev, vec_yvel_full_domain);;
+        Print() << "ad zeta" << std::endl;
+        average_down_with_grow_cells(lev, vec_zeta_full_domain);;
+        Print() << "ad done" << std::endl;
+    }
+}
+
 /**
  * @param lev Integer specifying the current level
  */

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -455,12 +455,17 @@ void REMORA::resize_stuff(int lev)
     vec_ubar.resize(lev+1);
     vec_vbar.resize(lev+1);
     vec_zeta.resize(lev+1);
+    vec_zeta_full_domain.resize(hires_init_level+1);
     vec_mskr.resize(lev+1);
     vec_msku.resize(lev+1);
     vec_mskv.resize(lev+1);
     vec_mskp.resize(lev+1);
     vec_mskr3d.resize(lev+1);
     vec_sstore.resize(lev+1);
+
+    vec_cons_full_domain.resize(hires_init_level+1);
+    vec_xvel_full_domain.resize(hires_init_level+1);
+    vec_yvel_full_domain.resize(hires_init_level+1);
 
     vec_pm.resize(lev+1);
     vec_pn.resize(lev+1);

--- a/Source/Initialization/REMORA_prob_common.H
+++ b/Source/Initialization/REMORA_prob_common.H
@@ -29,8 +29,7 @@ public:
         REMORA const& /*remora*/,
         amrex::MultiFab& /*mf_cons*/,
         amrex::MultiFab& /*mf_xvel*/,
-        amrex::MultiFab& /*mf_yvel*/,
-        amrex::MultiFab& /*mf_zvel*/) {
+        amrex::MultiFab& /*mf_yvel*/) {
           amrex::Error("Initialization set to analytic but init_analytic_prob not defined in prob.cpp");
     }
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -1174,7 +1174,10 @@ private:
     /** \brief Initialize initial problem data from analytic functions */
     void init_analytic(int lev);
     /** \brief Initialize high resolution initial problem data from analytic functions */
-    void init_full_domain_analytic();
+    void init_full_domain_from_analytic();
+
+    /** \brief Initialize high resolution initial sea surface height from analytic functions */
+    void init_full_domain_zeta_from_analytic();
 
     /** \brief Allocate MultiFabs for state and evolution variables */
     void init_stuff (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm);

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -299,6 +299,14 @@ public:
     /** \brief multilevel data container for current step's z velocities (largely unused; W stored separately) */
     amrex::Vector<amrex::MultiFab*> zvel_new;
 
+    /** \brief multilevel data container for high res initial data: temperature, salinity, passive tracer  */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_cons_full_domain;
+    /** \brief multilevel data container for high res initial x velocities (u in ROMS) */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_xvel_full_domain;
+    /** \brief multilevel data container for high res initial y velocities (v in ROMS) */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_yvel_full_domain;
+    /** \brief multilevel data container for current step's z velocities (largely unused; W stored separately) */
+
     // Program state data is represented by vectors of pointers to AMReX Multifabs.
     // There is one pointer per level
 
@@ -443,6 +451,9 @@ public:
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_vbar;
     /** \brief free surface height (2D) */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_zeta;
+
+    /** \brief high resolution initial free surface height (2D) */
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_zeta_full_domain;
 
     /** \brief land/sea mask at cell centers (2D) */
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> vec_mskr;
@@ -1077,8 +1088,12 @@ public:
     /** \brief Full domain bathymetry data initialization from analytic */
     void init_bathymetry_full_domain_from_analytic ();
 
+    /** \brief Problem initialization from averaged-down high resolution data */
+    void set_init_data_averaged_down (int lev);
     /** \brief Problem initialization from NetCDF file */
     void init_data_from_netcdf (int lev);
+    /** \brief High resolution roblem initialization from NetCDF file */
+    void init_data_full_domain_from_netcdf ();
     /** \brief Boundary data initialization from NetCDF file */
     void init_bdry_from_netcdf (int lev);
     /** \brief Mask data initialization from NetCDF file */
@@ -1103,6 +1118,8 @@ public:
 
     /** \brief Allocate multifabs for storing full-domain bathymetry and grid vars data */
     void allocate_bathymetry_grid_vars_full_domain ();
+    /** \brief Allocate multifabs for storing full-domain high resolution initial data */
+    void allocate_init_full_domain ();
 
     /** \brief Convert data in a multifab from inverse days to inverse seconds */
     void convert_inv_days_to_inv_s (amrex::MultiFab*);
@@ -1151,6 +1168,8 @@ private:
 
     /** \brief Initialize initial problem data from analytic functions */
     void init_analytic(int lev);
+    /** \brief Initialize high resolution initial problem data from analytic functions */
+    void init_full_domain_analytic();
 
     /** \brief Allocate MultiFabs for state and evolution variables */
     void init_stuff (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm);
@@ -1529,6 +1548,14 @@ private:
     std::string nc_grid_file_hires;
     /** \brief Box for the full domain at nc_hires_grid_level */
     amrex::Box nc_hires_grid_box;
+
+    /** \brief Which level the high resolution initialization data is at */
+    int hires_init_level = -1;
+    /** \brief Init file for high resolution */
+    std::string nc_init_file_hires;
+    /** \brief Box for the full domain at nc_hires_init_level */
+    amrex::Box nc_hires_init_box;
+
     /** \brief Cumulative refinement ratio between level 0 and level i */
     amrex::Vector<amrex::IntVect> cum_ref_ratios;
 

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -941,6 +941,9 @@ public:
     /** \brief Initialize zeta from file or analytic */
     void set_zeta (int lev);
 
+    /** \brief Copy over zeta data that has been averaged down from high res */
+    void set_zeta_averaged_down (int lev);
+
     /** \brief Initialize bathymetry from file or analytic */
     void set_bathymetry (int lev);
 
@@ -1108,6 +1111,8 @@ public:
     void init_grid_vars_full_domain_from_netcdf ();
     /** \brief Sea-surface height data initialization from NetCDF file */
     void init_zeta_from_netcdf (int lev);
+    /** \brief Full-domain high res sea-surface height data initialization from NetCDF file */
+    void init_zeta_full_domain_from_netcdf ();
     /** \brief Coriolis parameter data initialization from NetCDF file */
     void init_coriolis_from_netcdf (int lev);
     /** \brief Climatology nudging coefficient initialization from NetCDF file */

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -595,7 +595,7 @@ REMORA::set_zeta (int lev)
         // data that has been averaged down
         if (lev > hires_init_level) {
             Real dummy_time = 0.0_rt;
-            FillCoarsePatch(lev,dummy_time,vec_zeta[lev].get(), vec_h[lev-1].get(),BCVars::cons_bc);
+            FillCoarsePatch(lev,dummy_time,vec_zeta[lev].get(), vec_zeta[lev-1].get(),BCVars::cons_bc);
         } else {
             set_zeta_averaged_down(lev);
             vec_zeta[lev]->FillBoundary(geom[lev].periodicity());
@@ -1451,13 +1451,17 @@ REMORA::init_only (int lev, Real time)
         init_bathymetry_full_domain_from_analytic();
     }
 
+    if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
+        allocate_init_full_domain();
+        init_full_domain_zeta_from_analytic();
+    }
+
     set_bathymetry(lev);
     set_zeta(lev);
     stretch_transform(lev);
 
     if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
-        allocate_init_full_domain();
-        init_full_domain_analytic();
+        init_full_domain_from_analytic();
     }
 
     if (lev==0) {
@@ -1477,6 +1481,10 @@ REMORA::init_only (int lev, Real time)
         } else {
             set_init_data_averaged_down(lev);
             set_zeta_to_Ztavg(lev); // MAYBE???
+            // Since set_grid_scale is usually called from init_analytic for analytic problems
+            if (solverChoice.ic_type == IC_Type::analytic) {
+                set_grid_scale(lev);
+            }
         }
     } else {
         if (lev > hires_init_level) {
@@ -1487,6 +1495,10 @@ REMORA::init_only (int lev, Real time)
         } else {
             set_init_data_averaged_down(lev);
             set_zeta_to_Ztavg(lev); // MAYBE???
+            if (solverChoice.ic_type == IC_Type::analytic) {
+                // Since set_grid_scale is usually called from init_analytic for analytic problems
+                set_grid_scale(lev);
+            }
         }
     }
 
@@ -1746,7 +1758,6 @@ REMORA::ReadParameters ()
     if (hires_init_level > max_level) {
         amrex::Abort("hires_init_level must be less than or equal to amr.max_level");
     }
-
 #ifdef REMORA_USE_PARTICLES
     readTracersParams();
 #endif
@@ -1761,6 +1772,17 @@ REMORA::ReadParameters ()
 
     }
     solverChoice.init_params(ncons);
+
+    // NOTE: This feature is not yet implemented because it will require passing x,y,z to prob functions.
+    // Currently these are accessed by passing a pointer to the REMORA class. However, this requires the
+    // coordinates at hires_init_level to already exist (and specifically for the hires_init_level level
+    // to already be initialized), which is generally not the case. A solution is to create a separate
+    // coordinates object that is passed to the prob functions instead of the REMORA object. Then x,y,z
+    // coordinates can be calculated at any level without the corresponding level having been created.
+    if (hires_init_level >= 0 and solverChoice.ic_type == IC_Type::analytic) {
+        amrex::Abort("Cannot do high-resolution initialization for analytic initial conditions. Not yet implemented");
+    }
+
 }
 
 

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -572,24 +572,35 @@ void
 REMORA::set_zeta (int lev)
 {
     BL_PROFILE("REMORA::set_zeta()");
-    if (solverChoice.ic_type == IC_Type::analytic) {
-        prob->init_analytic_zeta(lev, geom[lev], solverChoice, *this, *vec_zeta[lev]);
-
+    if (lev==0) {
+        if (hires_init_level < 0) {
+            if (solverChoice.ic_type == IC_Type::analytic) {
+                prob->init_analytic_zeta(lev, geom[lev], solverChoice, *this, *vec_zeta[lev]);
+            } else if (solverChoice.ic_type == IC_Type::netcdf) {
 #ifdef REMORA_USE_NETCDF
-    } else if (solverChoice.ic_type == IC_Type::netcdf) {
-        if (lev == 0) {
-            amrex::Print() << "Calling init_zeta_from_netcdf on level " << lev << std::endl;
-            init_zeta_from_netcdf(lev);
-            amrex::Print() << "Sea surface height loaded from netcdf file \n " << std::endl;
-        } else {
-            Real dummy_time = 0.0_rt;
-            FillCoarsePatch(lev,dummy_time,vec_zeta[lev].get(), vec_zeta[lev-1].get(),BCVars::cons_bc);
-        }
+                amrex::Print() << "Calling init_zeta_from_netcdf on level " << lev << std::endl;
+                init_zeta_from_netcdf(lev);
+                amrex::Print() << "Sea surface height loaded from netcdf file \n " << std::endl;
 #endif
+            } else {
+                amrex::Abort("Unknown IC_Type");
+            }
+        } else {
+            set_zeta_averaged_down(lev);
+        }
+        vec_zeta[lev]->FillBoundary(geom[lev].periodicity());
     } else {
-        Abort("Don't know this ic_type!");
+        // If our level is higher than the high resolution grid or initialization
+        // is analytic, interpolate from level below. Otherwise, copy over the bathymetry
+        // data that has been averaged down
+        if (lev > hires_init_level) {
+            Real dummy_time = 0.0_rt;
+            FillCoarsePatch(lev,dummy_time,vec_zeta[lev].get(), vec_h[lev-1].get(),BCVars::cons_bc);
+        } else {
+            set_zeta_averaged_down(lev);
+            vec_zeta[lev]->FillBoundary(geom[lev].periodicity());
+        }
     }
-    vec_zeta[lev]->FillBoundary(geom[lev].periodicity());
     set_zeta_average(lev);
 }
 
@@ -685,6 +696,17 @@ REMORA::set_grid_vars_averaged_down (int lev) {
  * @param[in   ] lev   level to operate on
  */
 void
+REMORA::set_zeta_averaged_down (int lev) {
+    ParallelCopy(*vec_zeta[lev].get(), *vec_zeta_full_domain[lev].get(), 0, 0, 1,
+            vec_zeta_full_domain[lev]->nGrowVect(),vec_zeta[lev]->nGrowVect());
+    FillPatch(lev, t_new[lev], *vec_zeta[lev], GetVecOfPtrs(vec_zeta), zeta_bc(), BdyVars::zeta,
+                  0, false,false,0,0,0.0,*vec_zeta[lev]);
+}
+
+/**
+ * @param[in   ] lev   level to operate on
+ */
+void
 REMORA::set_init_data_averaged_down (int lev) {
     ParallelCopy(*cons_new[lev], *vec_cons_full_domain[lev], 0, 0, ncons,
             vec_cons_full_domain[lev]->nGrowVect(),cons_new[lev]->nGrowVect());
@@ -692,14 +714,10 @@ REMORA::set_init_data_averaged_down (int lev) {
             vec_xvel_full_domain[lev]->nGrowVect(),xvel_new[lev]->nGrowVect());
     ParallelCopy(*yvel_new[lev], *vec_yvel_full_domain[lev], 0, 0, 1,
             vec_yvel_full_domain[lev]->nGrowVect(),yvel_new[lev]->nGrowVect());
-    ParallelCopy(*vec_zeta[lev].get(), *vec_zeta_full_domain[lev].get(), 0, 0, 1,
-            vec_zeta_full_domain[lev]->nGrowVect(),vec_zeta[lev]->nGrowVect());
 
     FillPatch(lev, t_new[lev], *cons_new[lev], cons_new, BCVars::cons_bc, BdyVars::t, 0, true, false,0,0,0.0,*cons_new[lev]);
     FillPatch(lev, t_new[lev], *xvel_new[lev], xvel_new, xvel_bc(), BdyVars::u, 0, true, false,0,0,0.0,*xvel_new[lev]);
     FillPatch(lev, t_new[lev], *yvel_new[lev], yvel_new, yvel_bc(), BdyVars::v, 0, true, false,0,0,0.0,*yvel_new[lev]);
-    FillPatch(lev, t_new[lev], *vec_zeta[lev], GetVecOfPtrs(vec_zeta), zeta_bc(), BdyVars::zeta,
-                  0, false,false,0,0,0.0,*vec_zeta[lev]);
 }
 
 /**
@@ -1416,6 +1434,7 @@ REMORA::init_only (int lev, Real time)
         amrex::Print() << "Reading high resolution initial data" << std::endl;
         allocate_init_full_domain();
         init_data_full_domain_from_netcdf();
+        init_zeta_full_domain_from_netcdf();
         amrex::Print() << "Done reading in high resolution initial data" << std::endl;
     }
 #else
@@ -1661,6 +1680,7 @@ REMORA::ReadParameters ()
     }
 
     pp.queryAdd("nc_grid_file_hires", nc_grid_file_hires);
+    pp.queryAdd("nc_init_file_hires", nc_init_file_hires);
 
     // We only read boundary data at level 0
     pp.queryarr("nc_bdry_file", nc_bdry_file);
@@ -1721,6 +1741,10 @@ REMORA::ReadParameters ()
     pp.queryAdd("hires_grid_level", hires_grid_level);
     if (hires_grid_level > max_level) {
         amrex::Abort("hires_grid_level must be less than or equal to amr.max_level");
+    }
+    pp.queryAdd("hires_init_level", hires_init_level);
+    if (hires_init_level > max_level) {
+        amrex::Abort("hires_init_level must be less than or equal to amr.max_level");
     }
 
 #ifdef REMORA_USE_PARTICLES
@@ -1790,7 +1814,7 @@ REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<Multi
     auto index_type = (vec_mf[crse_lev]->boxArray().ixType()).toIntVect();
     auto nghost_crse = cum_ref_ratios[crse_lev] - index_type;
     if (index_type[0]==0 and index_type[1]==0) {
-        ParallelFor(*vec_mf[crse_lev], nghost_crse, 1,
+        ParallelFor(*vec_mf[crse_lev], nghost_crse, vec_mf[crse_lev]->nComp(),
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],0,0,ref_ratio_crse);

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -123,6 +123,8 @@ REMORA::REMORA ()
     // Initialize tagging criteria for mesh refinement
     refinement_criteria_setup();
 
+    IntVect cum_ref_ratio = IntVect(1,1,0);
+    cum_ref_ratios.push_back(cum_ref_ratio);
     // We have already read in the ref_Ratio (via amr.ref_ratio =) but we need to enforce
     //     that there is no refinement in the vertical so we test on that here.
     for (int lev = 0; lev < max_level; ++lev)
@@ -138,6 +140,10 @@ REMORA::REMORA ()
            amrex::Print() << "********************************************************************************" << std::endl;
            amrex::Abort();
        }
+
+       cum_ref_ratio[0] *= ref_ratio[lev][0];
+       cum_ref_ratio[1] *= ref_ratio[lev][1];
+       cum_ref_ratios.push_back(cum_ref_ratio);
     }
 }
 
@@ -673,6 +679,27 @@ REMORA::set_grid_vars_averaged_down (int lev) {
     FillPatch(lev,dummy_time,*vec_pn[lev],GetVecOfPtrs(vec_pn),
             foextrap_periodic_bc(),
             BdyVars::null,0,false,true);
+}
+
+/**
+ * @param[in   ] lev   level to operate on
+ */
+void
+REMORA::set_init_data_averaged_down (int lev) {
+    ParallelCopy(*cons_new[lev], *vec_cons_full_domain[lev], 0, 0, ncons,
+            vec_cons_full_domain[lev]->nGrowVect(),cons_new[lev]->nGrowVect());
+    ParallelCopy(*xvel_new[lev], *vec_xvel_full_domain[lev], 0, 0, 1,
+            vec_xvel_full_domain[lev]->nGrowVect(),xvel_new[lev]->nGrowVect());
+    ParallelCopy(*yvel_new[lev], *vec_yvel_full_domain[lev], 0, 0, 1,
+            vec_yvel_full_domain[lev]->nGrowVect(),yvel_new[lev]->nGrowVect());
+    ParallelCopy(*vec_zeta[lev].get(), *vec_zeta_full_domain[lev].get(), 0, 0, 1,
+            vec_zeta_full_domain[lev]->nGrowVect(),vec_zeta[lev]->nGrowVect());
+
+    FillPatch(lev, t_new[lev], *cons_new[lev], cons_new, BCVars::cons_bc, BdyVars::t, 0, true, false,0,0,0.0,*cons_new[lev]);
+    FillPatch(lev, t_new[lev], *xvel_new[lev], xvel_new, xvel_bc(), BdyVars::u, 0, true, false,0,0,0.0,*xvel_new[lev]);
+    FillPatch(lev, t_new[lev], *yvel_new[lev], yvel_new, yvel_bc(), BdyVars::v, 0, true, false,0,0,0.0,*yvel_new[lev]);
+    FillPatch(lev, t_new[lev], *vec_zeta[lev], GetVecOfPtrs(vec_zeta), zeta_bc(), BdyVars::zeta,
+                  0, false,false,0,0,0.0,*vec_zeta[lev]);
 }
 
 /**
@@ -1385,6 +1412,12 @@ REMORA::init_only (int lev, Real time)
         init_grid_vars_full_domain_from_netcdf();
         amrex::Print() << "Done reading in high resolution bathymetry and grid data" << std::endl;
     }
+    if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::netcdf) {
+        amrex::Print() << "Reading high resolution initial data" << std::endl;
+        allocate_init_full_domain();
+        init_data_full_domain_from_netcdf();
+        amrex::Print() << "Done reading in high resolution initial data" << std::endl;
+    }
 #else
     if (solverChoice.boundary_from_netcdf) {
         Abort("Not compiled with NetCDF, but selected boundary conditions require NetCDF");
@@ -1403,45 +1436,39 @@ REMORA::init_only (int lev, Real time)
     set_zeta(lev);
     stretch_transform(lev);
 
-    if (solverChoice.init_l0int_T) {
-        if (lev==0) {
-            if (solverChoice.ic_type == IC_Type::analytic)
-            {
+    if (lev==0 and hires_init_level > 0 and solverChoice.ic_type == IC_Type::analytic) {
+        allocate_init_full_domain();
+        init_full_domain_analytic();
+    }
+
+    if (lev==0) {
+        if (hires_init_level < 0) {
+            if (solverChoice.ic_type == IC_Type::analytic) {
                 init_analytic(lev);
-#ifdef REMORA_USE_NETCDF
             } else if (solverChoice.ic_type == IC_Type::netcdf) {
+#ifdef REMORA_USE_NETCDF
                 amrex::Print() << "Calling init_data_from_netcdf " << std::endl;
                 init_data_from_netcdf(lev);
                 set_zeta_to_Ztavg(lev);
                 amrex::Print() << "Initial data loaded from netcdf file \n " << std::endl;
-
 #endif
             } else {
-                Abort("Need to specify ic_type");
+                amrex::Abort("Unknown IC_Type");
             }
         } else {
+            set_init_data_averaged_down(lev);
+            set_zeta_to_Ztavg(lev); // MAYBE???
+        }
+    } else {
+        if (lev > hires_init_level) {
             FillCoarsePatch(lev, time, cons_new[lev], cons_new[lev-1],BCVars::Temp_bc_comp,BdyVars::t);
             FillCoarsePatch(lev, time, xvel_new[lev], xvel_new[lev-1], xvel_bc(), BdyVars::u);
             FillCoarsePatch(lev, time, yvel_new[lev], yvel_new[lev-1], yvel_bc(), BdyVars::v);
             FillCoarsePatch(lev, time, zvel_new[lev], zvel_new[lev-1], zvel_bc(), BdyVars::null);
-        }
-    } else if (solverChoice.init_ana_T || solverChoice.init_l1ad_T) {
-        if (solverChoice.ic_type == IC_Type::analytic)
-        {
-            init_analytic(lev);
-#ifdef REMORA_USE_NETCDF
-        } else if (solverChoice.ic_type == IC_Type::netcdf) {
-            amrex::Print() << "Calling init_data_from_netcdf on level " << lev << std::endl;
-            init_data_from_netcdf(lev);
-            set_zeta_to_Ztavg(lev);
-            amrex::Print() << "Initial data loaded from netcdf file on level " << lev << std::endl;
-
-#endif
         } else {
-            Abort("Need to specify ic_type");
+            set_init_data_averaged_down(lev);
+            set_zeta_to_Ztavg(lev); // MAYBE???
         }
-    } else {
-        amrex::Abort("Need to specify T init procedure");
     }
 
     // Ensure that the face-based data are the same on both sides of a periodic domain.
@@ -1534,6 +1561,13 @@ REMORA::ReadParameters ()
     }
     AMREX_ASSERT(cfl > 0. || fixed_dt > 0.);
 
+    num_files_at_level.resize(max_level + 1, 0);
+    num_boxes_at_level.resize(max_level + 1, 0);
+    boxes_at_level.resize(max_level + 1);
+    num_boxes_at_level[0] = 1;
+    boxes_at_level[0].resize(1);
+    boxes_at_level[0][0] = geom[0].Domain();
+
     pp.queryAdd("plot_file", plot_file_name);
     pp.queryAdd("plot_int", plot_int);
     pp.queryAdd("plot_int_time", plot_int_time);
@@ -1593,6 +1627,7 @@ REMORA::ReadParameters ()
     nc_grid_file.resize(max_level+1);
 
     boundary_series.resize(max_level+1);
+
 
     // NetCDF initialization files -- possibly multiple files at each of multiple levels
     //        but we always have exactly one file at level 0
@@ -1696,14 +1731,7 @@ REMORA::ReadParameters ()
             amrex::Abort("Time substepping is not yet implemented. amr.do_substep must be 0");
         }
 
-        num_files_at_level.resize(max_level + 1, 0);
-        num_boxes_at_level.resize(max_level + 1, 0);
-        boxes_at_level.resize(max_level + 1);
-        num_boxes_at_level[0] = 1;
-        boxes_at_level[0].resize(1);
-        boxes_at_level[0][0] = geom[0].Domain();
     }
-
     solverChoice.init_params(ncons);
 }
 
@@ -1750,7 +1778,7 @@ REMORA::AverageDownTo (int crse_lev)
  * @param[inout] vec_mf     vector over levels of multifabs containing data to average
  */
 void
-REMORA::average_down_with_grow_cells(int crse_lev, Vector<std::unique_ptr<MultiFab>>& vec_mf)
+REMORA::average_down_with_grow_cells (int crse_lev, Vector<std::unique_ptr<MultiFab>>& vec_mf)
 {
     auto const& crsema = vec_mf[crse_lev]->arrays();
     auto const& finema = vec_mf[crse_lev+1]->const_arrays();


### PR DESCRIPTION
Currently only works for NetCDF initialization. Analytic initialization will cause an error for now.