### PR TITLE
Updated handling of evap minus precipitation

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1233,22 +1233,46 @@ List of Bulk Fluxes parameters
 |                                      |                                        |                   |                |
 |                                      | NetCDF file                            |                   |                |
 +--------------------------------------+----------------------------------------+-------------------+----------------+
-| **remora.EminusP_from_netcdf**       | Load evaporation minus                 | true / false      | false          |
-|                                      |                                        |                   |                |
-|                                      | precipitation from NetCDF file         |                   |                |
-|                                      |                                        |                   |                |
+| **remora.EminusP_from_netcdf**       | Use NetCDF ``EminusP`` as the         | true / false      | false          |
+|                                      | E-P source for salt/freshwater        |                   |                |
+|                                      | flux (used only if                     |                   |                |
+|                                      | ``remora.eminusp`` = true)            |                   |                |
 |                                      |                                        |                   |                |
 +--------------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.eminusp**                   | Whether to do E-P prescription for     | true / false      | false          |
 |                                      |                                        |                   |                |
-|                                      | evaporation/precipiation               |                   |                |
+|                                      | evaporation/precipitation. If false,   |                   |                |
+|                                      | E-P is computed diagnostically as      |                   |                |
+|                                      | evaporation minus rain                 |                   |                |
 +--------------------------------------+----------------------------------------+-------------------+----------------+
 | **remora.eminusp_correct_ssh**       | Whether to adjust sea surface          | true / false      | false          |
 |                                      |                                        |                   |                |
-|                                      | height for amount of evaporation       |                   |                |
+|                                      | height for amount of E-P               |                   |                |
 |                                      |                                        |                   |                |
 |                                      | and precipitation                      |                   |                |
 +--------------------------------------+----------------------------------------+-------------------+----------------+
+
+.. note::
+
+    E-P option behavior when ``remora.bulk_fluxes = true``:
+
+    - If ``remora.eminusp = false``, E-P is computed diagnostically as
+       evaporation minus rain.
+    - If ``remora.eminusp = true`` and ``remora.EminusP_from_netcdf = false``,
+       E-P is computed diagnostically from bulk evaporation minus rain.
+    - If ``remora.eminusp = true`` and ``remora.EminusP_from_netcdf = true``,
+       NetCDF ``EminusP`` is used directly.
+
+    Consistency constraints enforced at runtime:
+
+    - ``remora.eminusp = true`` requires ``remora.bulk_fluxes = true``.
+    - ``remora.eminusp_correct_ssh = true`` requires
+       ``remora.bulk_fluxes = true``.
+
+    When ``remora.eminusp_correct_ssh = true``, SSH correction uses the active
+    E-P source: NetCDF ``EminusP`` when both ``remora.eminusp = true`` and
+    ``remora.EminusP_from_netcdf = true``; otherwise diagnostic evaporation
+    minus rain is used.
 
 .. note::
 

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -862,14 +862,22 @@ REMORA::set_zeta_to_Ztavg (int lev)
             Array4<Real> const& Zt_avg1 = (mf_Zt_avg1)->array(mfi);
             Array4<const Real> const& evap = vec_evap[lev]->const_array(mfi);
             Array4<const Real> const& rain = vec_rain[lev]->const_array(mfi);
+            Array4<const Real> const& EminusP = vec_EminusP[lev]->const_array(mfi);
+            bool use_EminusP_from_file = solverChoice.eminusp && solverChoice.EminusP_from_netcdf;
 
             Box  bx2 = mfi.growntilebox(IntVect(NGROW,NGROW,0));// bx2.grow(IntVect(NGROW,NGROW,0));
 
             Real cff = dt[lev] / rhow;
+            Real dt_lev = dt[lev];
 
             ParallelFor(bx2, [=] AMREX_GPU_DEVICE (int i, int j, int )
             {
-                Zt_avg1(i,j,0) = Zt_avg1(i,j,0) - (evap(i,j,0) - rain(i,j,0)) * cff;
+                if (use_EminusP_from_file) {
+                    // EminusP is treated as a kinematic freshwater flux (m/s).
+                    Zt_avg1(i,j,0) = Zt_avg1(i,j,0) - EminusP(i,j,0) * dt_lev;
+                } else {
+                    Zt_avg1(i,j,0) = Zt_avg1(i,j,0) - (evap(i,j,0) - rain(i,j,0)) * cff;
+                }
             });
         }
     }

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -230,11 +230,23 @@ struct SolverChoice {
             amrex::Warning("remora.longwave_netcdf_varname is set but remora.longwave_down_from_netcdf is false; the value will be ignored.");
         }
 
-        if (eminusp_correct_ssh and !eminusp) {
-            amrex::Abort("If evaporation minus precipitation (E-P) sea surface height correct in is on, E-P must be on as well (remora.eminusp=true)");
+        if (eminusp_correct_ssh and !bulk_fluxes) {
+            amrex::Abort("If evaporation minus precipitation (E-P) sea surface height correction is on, bulk fluxes must be on as well (remora.bulk_fluxes=true)");
         }
         if (eminusp and !bulk_fluxes) {
             amrex::Abort("Evaporation minus precipitation (E-P) requires bulk flux parametrizations (remora.bulk_fluxes=true)");
+        }
+
+        {
+            static bool printed_ep_source = false;
+            if (!printed_ep_source) {
+                printed_ep_source = true;
+                if (bulk_fluxes && eminusp && EminusP_from_netcdf) {
+                    amrex::Print() << "[REMORA] Active E-P source: NetCDF EminusP (remora.EminusP_from_netcdf=true).\n";
+                } else {
+                    amrex::Print() << "[REMORA] Active E-P source: bulk evap-rain diagnostic.\n";
+                }
+            }
         }
 
         //Read in linear eos parameters

--- a/Source/TimeIntegration/REMORA_bulk_flux.cpp
+++ b/Source/TimeIntegration/REMORA_bulk_flux.cpp
@@ -65,6 +65,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         Array4<const Real> const& msku  = vec_msku[lev]->const_array(mfi);
         Array4<const Real> const& mskv  = vec_mskv[lev]->const_array(mfi);
         Array4<const Real> const& rain  = vec_rain[lev]->const_array(mfi);
+        Array4<const Real> const& EminusP = vec_EminusP[lev]->const_array(mfi);
         Array4<const Real> const& cloud_arr = vec_cloud[lev]->const_array(mfi);
 
         Real Hscale = solverChoice.rho0 * Cp;
@@ -76,6 +77,7 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
         bool use_longwave_down = solverChoice.longwave_down;
         bool longwave_netcdf_is_net = solverChoice.longwave_netcdf_is_net;
         bool have_longwave_from_file = (mf_longwave_down != nullptr);
+        bool use_EminusP_from_file = solverChoice.eminusp && solverChoice.EminusP_from_netcdf;
 
         Real eps = 1e-20_rt;
 
@@ -389,7 +391,12 @@ REMORA::bulk_fluxes (int lev, MultiFab* mf_cons, MultiFab* mf_uwind, MultiFab* m
             // Note: srflx from NetCDF is in W/m², convert to degC m/s by multiplying by Hscale2
             stflux(i,j,0,Temp_comp)=(srflux*Hscale2 + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0)) * mskr(i,j,0);
             evap(i,j,0) = (LHeat / Hlv+eps) * mskr(i,j,0);
-            stflux(i,j,0,Salt_comp) = mskr(i,j,0) * (evap(i,j,0)-rain(i,j,0)) / rhow;
+            if (use_EminusP_from_file) {
+                // Match ROMS BULK_FLUXES + !EMINUSP behavior: use NetCDF E-P directly (m/s).
+                stflux(i,j,0,Salt_comp) = mskr(i,j,0) * EminusP(i,j,0);
+            } else {
+                stflux(i,j,0,Salt_comp) = mskr(i,j,0) * (evap(i,j,0)-rain(i,j,0)) / rhow;
+            }
         });
 
         Real cff_rho = 0.5_rt / solverChoice.rho0;


### PR DESCRIPTION
Updated to allow for loading E minus P directly from netcdf or computing it diagnostically within the bulk flux calculations. Documentation is updated to reflect how to use either option. 