### PR TITLE
Add imported atm->ocn flux mode

### DIFF
--- a/Source/IO/REMORA_Plotfile.cpp
+++ b/Source/IO/REMORA_Plotfile.cpp
@@ -230,28 +230,28 @@ REMORA::WritePlotFile (int istep_for_plot)
             }
         }
         if (plot_name == "lrflux" ) {
-            if (!solverChoice.bulk_fluxes) {
+            if (!solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode) {
                 amrex::Abort("Attempting to write longwave radiation flux to plotfile. Variable not allocated when bulk_fluxes turned off");
             }
             for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_rho[lev],*vec_lrflx[lev],0,icomp_rho,1,0); }
             icomp_rho++;
         }
         if (plot_name == "lhflux" ) {
-            if (!solverChoice.bulk_fluxes) {
+            if (!solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode) {
                 amrex::Abort("Attempting to write latent heat flux to plotfile. Variable not allocated when bulk_fluxes turned off");
             }
             for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_rho[lev],*vec_lhflx[lev],0,icomp_rho,1,0); }
             icomp_rho++;
         }
         if (plot_name == "srflux" ) {
-            if (!solverChoice.bulk_fluxes) {
+            if (!solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode) {
                 amrex::Abort("Attempting to write shortwave radiation flux to plotfile. Variable not allocated when bulk_fluxes turned off");
             }
             for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_rho[lev],*vec_srflx[lev],0,icomp_rho,1,0); }
             icomp_rho++;
         }
         if (plot_name == "shflux" ) {
-            if (!solverChoice.bulk_fluxes) {
+            if (!solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode) {
                 amrex::Abort("Attempting to write sensible heat flux to plotfile. Variable not allocated when bulk_fluxes turned off");
             }
             for (int lev = 0; lev <= finest_level; ++lev) { MultiFab::Copy(mf_2d_rho[lev],*vec_shflx[lev],0,icomp_rho,1,0); }

--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -661,7 +661,7 @@ void REMORA::init_stuff (int lev, const BoxArray& ba, const DistributionMapping&
     vec_stflux[lev].reset(new MultiFab(ba2d,dm,ncons,IntVect(NGROW,NGROW,0)));
     vec_btflux[lev].reset(new MultiFab(ba2d,dm,ncons,IntVect(NGROW,NGROW,0)));
 
-    if (solverChoice.bulk_fluxes) {
+    if (solverChoice.bulk_fluxes || solverChoice.atm2ocn_flux_mode) {
         vec_uwind[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, surface wind u
         vec_vwind[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0))); //2d, surface wind v
         vec_Tair[lev].reset(new MultiFab(ba2d,dm,1,IntVect(NGROW,NGROW,0)));  //2d, air temperature

--- a/Source/REMORA.H
+++ b/Source/REMORA.H
@@ -163,6 +163,18 @@ public:
      */
     void ApplyAtmosphericStates (const amrex::Vector<amrex::MultiFab*>& states, amrex::Real time);
 
+    /**
+     * \brief Receives atmospheric flux lanes from the driver and assembles REMORA flux inputs.
+     *
+     * Expected active-lane order matches the driver FluxPassing contract:
+     * tau_x, tau_y, SHflux, LHflux, SWrad, LWrad, rain, evap.
+     *
+     * This routine copies imported forcing lanes into REMORA's existing flux arrays
+     * and assembles vec_stflux directly from those imported values. It intentionally
+     * leaves the downstream salt_old multiplication to setup_step().
+     */
+    void ApplyAtmosphericFluxes (const amrex::Vector<amrex::MultiFab*>& states, amrex::Real time);
+
     // Diagnostics
 
     /** \brief Integrate conserved quantities for diagnostics */

--- a/Source/REMORA_Coupling.cpp
+++ b/Source/REMORA_Coupling.cpp
@@ -376,7 +376,20 @@ REMORA::ApplyAtmosphericFluxes (const Vector<MultiFab*>& states, Real /*time*/)
     vec_lrflx[0]->FillBoundary(geom[0].periodicity());
     vec_lhflx[0]->FillBoundary(geom[0].periodicity());
     vec_shflx[0]->FillBoundary(geom[0].periodicity());
+    vec_stflux[0]->FillBoundary(geom[0].periodicity());
     vec_rain[0]->FillBoundary(geom[0].periodicity());
     vec_evap[0]->FillBoundary(geom[0].periodicity());
     vec_stflux[0]->FillBoundary(geom[0].periodicity());
+
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "REMORA ApplyAtmosphericFluxes validation:\n"
+                       << "  sustr: min=" << vec_sustr[0]->min(0) << " max=" << vec_sustr[0]->max(0) << "\n"
+                       << "  svstr: min=" << vec_svstr[0]->min(0) << " max=" << vec_svstr[0]->max(0) << "\n"
+                       << "  stflux(Temp): min=" << vec_stflux[0]->min(Temp_comp) << " max=" << vec_stflux[0]->max(Temp_comp) << "\n"
+                       << "  stflux(Salt): min=" << vec_stflux[0]->min(Salt_comp) << " max=" << vec_stflux[0]->max(Salt_comp) << "\n"
+                       << "  srflx: min=" << vec_srflx[0]->min(0) << " max=" << vec_srflx[0]->max(0) << "\n"
+                       << "  lrflx: min=" << vec_lrflx[0]->min(0) << " max=" << vec_lrflx[0]->max(0) << "\n"
+                       << "  lhflx: min=" << vec_lhflx[0]->min(0) << " max=" << vec_lhflx[0]->max(0) << "\n"
+                       << "  shflx: min=" << vec_shflx[0]->min(0) << " max=" << vec_shflx[0]->max(0) << "\n";
+    }
 }

--- a/Source/REMORA_Coupling.cpp
+++ b/Source/REMORA_Coupling.cpp
@@ -285,3 +285,98 @@ REMORA::ApplyAtmosphericStates (const Vector<MultiFab*>& states, Real /*time*/)
     }
 
 }
+
+void
+REMORA::ApplyAtmosphericFluxes (const Vector<MultiFab*>& states, Real /*time*/)
+{
+    driver_atmos_state_from_driver.fill(false);
+    if (finest_level < 0) { return; }
+
+    if (states.size() <= AtmosFluxes::Evap ||
+        states[AtmosFluxes::TauX] == nullptr ||
+        states[AtmosFluxes::TauY] == nullptr ||
+        states[AtmosFluxes::SHflux] == nullptr ||
+        states[AtmosFluxes::LHflux] == nullptr ||
+        states[AtmosFluxes::SWrad] == nullptr ||
+        states[AtmosFluxes::LWrad] == nullptr ||
+        states[AtmosFluxes::Rain] == nullptr ||
+        states[AtmosFluxes::Evap] == nullptr ||
+        vec_sustr[0] == nullptr || vec_svstr[0] == nullptr ||
+        vec_stflux[0] == nullptr || vec_mskr[0] == nullptr ||
+        vec_msku[0] == nullptr || vec_mskv[0] == nullptr ||
+        vec_srflx[0] == nullptr || vec_lrflx[0] == nullptr ||
+        vec_lhflx[0] == nullptr || vec_shflx[0] == nullptr ||
+        vec_rain[0] == nullptr || vec_evap[0] == nullptr) {
+        return;
+    }
+
+    const Real Hscale2 = 1.0_rt / (solverChoice.rho0 * Cp);
+
+    vec_srflx[0]->ParallelCopy(*states[AtmosFluxes::SWrad], 0, 0, 1);
+    vec_rain[0]->ParallelCopy(*states[AtmosFluxes::Rain], 0, 0, 1);
+    vec_evap[0]->ParallelCopy(*states[AtmosFluxes::Evap], 0, 0, 1);
+
+    for (MFIter mfi(*vec_stflux[0], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        Array4<Real> const& stflux = vec_stflux[0]->array(mfi);
+        Array4<Real> const& sustr = vec_sustr[0]->array(mfi);
+        Array4<Real> const& svstr = vec_svstr[0]->array(mfi);
+        Array4<Real> const& lrflx = vec_lrflx[0]->array(mfi);
+        Array4<Real> const& lhflx = vec_lhflx[0]->array(mfi);
+        Array4<Real> const& shflx = vec_shflx[0]->array(mfi);
+        Array4<const Real> const& mskr = vec_mskr[0]->const_array(mfi);
+        Array4<const Real> const& msku = vec_msku[0]->const_array(mfi);
+        Array4<const Real> const& mskv = vec_mskv[0]->const_array(mfi);
+        Array4<const Real> const& srflx = vec_srflx[0]->const_array(mfi);
+        Array4<const Real> const& rain = vec_rain[0]->const_array(mfi);
+        Array4<const Real> const& evap = vec_evap[0]->const_array(mfi);
+        Array4<const Real> const& tau_x = states[AtmosFluxes::TauX]->const_array(mfi);
+        Array4<const Real> const& tau_y = states[AtmosFluxes::TauY]->const_array(mfi);
+        Array4<const Real> const& shflux = states[AtmosFluxes::SHflux]->const_array(mfi);
+        Array4<const Real> const& lhflux = states[AtmosFluxes::LHflux]->const_array(mfi);
+        Array4<const Real> const& lwflux = states[AtmosFluxes::LWrad]->const_array(mfi);
+
+        Box gbx2 = mfi.growntilebox(IntVect(NGROW,NGROW,0));
+        Box gbx2D = gbx2;
+        gbx2D.makeSlab(2,0);
+        Box ubx = mfi.grownnodaltilebox(0, IntVect(NGROW,NGROW,0));
+        Box ubxD = ubx;
+        ubxD.makeSlab(2,0);
+        Box vbx = mfi.grownnodaltilebox(1, IntVect(NGROW,NGROW,0));
+        Box vbxD = vbx;
+        vbxD.makeSlab(2,0);
+
+        ParallelFor(ubxD, [=] AMREX_GPU_DEVICE (int i, int j, int ) {
+            sustr(i,j,0) = Real(0.5) / solverChoice.rho0
+                         * (tau_x(i-1,j,0) + tau_x(i,j,0))
+                         * msku(i,j,0);
+        });
+
+        ParallelFor(vbxD, [=] AMREX_GPU_DEVICE (int i, int j, int ) {
+            svstr(i,j,0) = Real(0.5) / solverChoice.rho0
+                         * (tau_y(i,j-1,0) + tau_y(i,j,0))
+                         * mskv(i,j,0);
+        });
+
+        ParallelFor(gbx2D, [=] AMREX_GPU_DEVICE (int i, int j, int ) {
+            // ERF exports flux lanes in native surface-flux units; convert once at ingest.
+            lrflx(i,j,0) = lwflux(i,j,0) * Hscale2;
+            lhflx(i,j,0) = -lhflux(i,j,0) * Hscale2;
+            shflx(i,j,0) = -shflux(i,j,0) * Hscale2;
+            stflux(i,j,0,Temp_comp) =
+                (srflx(i,j,0) * Hscale2 + lrflx(i,j,0) + lhflx(i,j,0) + shflx(i,j,0))
+                * mskr(i,j,0);
+            stflux(i,j,0,Salt_comp) =
+                mskr(i,j,0) * (evap(i,j,0) - rain(i,j,0)) / rhow;
+        });
+    }
+
+    vec_sustr[0]->FillBoundary(geom[0].periodicity());
+    vec_svstr[0]->FillBoundary(geom[0].periodicity());
+    vec_srflx[0]->FillBoundary(geom[0].periodicity());
+    vec_lrflx[0]->FillBoundary(geom[0].periodicity());
+    vec_lhflx[0]->FillBoundary(geom[0].periodicity());
+    vec_shflx[0]->FillBoundary(geom[0].periodicity());
+    vec_rain[0]->FillBoundary(geom[0].periodicity());
+    vec_evap[0]->FillBoundary(geom[0].periodicity());
+    vec_stflux[0]->FillBoundary(geom[0].periodicity());
+}

--- a/Source/REMORA_DataStruct.H
+++ b/Source/REMORA_DataStruct.H
@@ -191,7 +191,16 @@ struct SolverChoice {
         pp.queryAdd("rho0", rho0);
 
         pp.queryAdd("bulk_fluxes",bulk_fluxes);
-        if (bulk_fluxes) {
+        pp.queryAdd("atm2ocn_flux_mode", atm2ocn_flux_mode);
+        {
+            amrex::ParmParse pp_driver("driver");
+            std::string driver_atm2ocn_mode = "state";
+            pp_driver.query("atm2ocn_mode", driver_atm2ocn_mode);
+            if (amrex::toLower(driver_atm2ocn_mode) == "flux") {
+                atm2ocn_flux_mode = true;
+            }
+        }
+        if (bulk_fluxes || atm2ocn_flux_mode) {
             do_salt_flux = true;
             do_temp_flux = true;
         }
@@ -624,6 +633,7 @@ struct SolverChoice {
     bool        use_curvilinear_grid  = false;
 
     bool        bulk_fluxes           = false;
+    bool        atm2ocn_flux_mode     = false;
 
     bool        output_forcing        = false;
     bool        do_temp_flux          = false;

--- a/Source/REMORA_IndexDefines.H
+++ b/Source/REMORA_IndexDefines.H
@@ -84,6 +84,27 @@ namespace AtmosState {
     };
 }
 
+/**
+ * \brief Index constants for the driver ATM->OCN flux-passing active view.
+ *
+ * Order mirrors AtmosToOceanActiveIndices(FluxPassing) from
+ * ERFRemoraCouplingContract.H:
+ * tau_x, tau_y, SHflux, LHflux, SWrad, LWrad, rain, evap.
+ */
+namespace AtmosFluxes {
+    enum {
+        TauX = 0,  ///< surface zonal stress lane
+        TauY,      ///< surface meridional stress lane
+        SHflux,    ///< sensible heat flux lane
+        LHflux,    ///< latent heat flux lane
+        SWrad,     ///< shortwave radiation lane
+        LWrad,     ///< longwave flux lane
+        Rain,      ///< precipitation rate lane
+        Evap,      ///< evaporation rate lane
+        NumTypes
+    };
+}
+
 enum struct REMORA_BC {
     symmetry, inflow, outflow, no_slip_wall, slip_wall, periodic,
     clamped, chapman, flather, orlanski_rad, orlanski_rad_nudge, undefined

--- a/Source/TimeIntegration/REMORA_setup_step.cpp
+++ b/Source/TimeIntegration/REMORA_setup_step.cpp
@@ -109,7 +109,9 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
     // If we're not doing bulk fluxes, set surface momentum fluxes directly.
     // Otherwise, calculate them from winds, so those need to be set
-    if (!solverChoice.bulk_fluxes) {
+    if (solverChoice.atm2ocn_flux_mode) {
+        // Surface stress and heat/moisture fluxes were already populated from the driver.
+    } else if (!solverChoice.bulk_fluxes) {
         set_smflux(lev);
     } else {
         set_wind(lev);
@@ -135,8 +137,10 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
         Array4<Real      > const& rhoA  = mf_rhoA->array(mfi);
         Array4<Real      > const& rhoS  = mf_rhoS->array(mfi);
         Array4<Real      > const& bvf   = mf_bvf->array(mfi);
-        Array4<Real      > const& alpha = (solverChoice.bulk_fluxes) ? vec_alpha[lev]->array(mfi) : Array4<Real>();
-        Array4<Real      > const& beta  = (solverChoice.bulk_fluxes) ? vec_beta[lev]->array(mfi)  : Array4<Real>();
+        Array4<Real      > const& alpha = (solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode)
+                                            ? vec_alpha[lev]->array(mfi) : Array4<Real>();
+        Array4<Real      > const& beta  = (solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode)
+                                            ? vec_beta[lev]->array(mfi)  : Array4<Real>();
 
         Array4<Real const> const& pm = mf_pm->const_array(mfi);
         Array4<Real const> const& pn = mf_pn->const_array(mfi);
@@ -192,7 +196,7 @@ REMORA::setup_step (int lev, Real time, Real dt_lev)
 
     if (solverChoice.longwave_down_from_netcdf)
         lw_ptr = vec_longwave_down[lev].get();
-    if (solverChoice.bulk_fluxes) {
+    if (solverChoice.bulk_fluxes && !solverChoice.atm2ocn_flux_mode) {
         bulk_fluxes(lev, cons_old[lev],vec_uwind[lev].get(),vec_vwind[lev].get(),
                     vec_Tair[lev].get(),vec_qair[lev].get(),vec_Pair[lev].get(),
                     vec_srflx[lev].get(),


### PR DESCRIPTION
- Add atm2ocn_flux_mode and allocate forcing arrays outside bulk_fluxes.
- Add ApplyAtmosphericFluxes to ingest lanes and assemble stflux.
- Skip bulk_fluxes/set_smflux overrides while keeping flux diagnostics writable.