### PR TITLE
Use cuda arch cmake flag in gh action

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -19,6 +19,7 @@ jobs:
         include:
           - cuda_ver: "12.6"
             cuda_pkg: 12-6
+            cuda_arch: "8.0"
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1
@@ -59,6 +60,7 @@ jobs:
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
             -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON \
+            -DAMReX_CUDA_ARCH=${{matrix.cuda_arch}} \
             -DREMORA_DIM:STRING=3 \
             -DREMORA_ENABLE_MPI:BOOL=OFF \
             -DREMORA_ENABLE_CUDA:BOOL=ON .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,38 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+function(remora_normalize_cuda_arch_list input output_var)
+  set(_normalized)
+  foreach(_arch IN LISTS ${input})
+    set(_entry "${_arch}")
+    string(REPLACE "+PTX" "" _entry "${_entry}")
+    string(REPLACE "." "" _entry "${_entry}")
+    if(_entry)
+      list(APPEND _normalized "${_entry}")
+    endif()
+  endforeach()
+  set(${output_var} "${_normalized}" PARENT_SCOPE)
+endfunction()
+
 if(REMORA_ENABLE_CUDA)
   enable_language(CUDA)
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "9.0")
     message(FATAL_ERROR "Your nvcc version is ${CMAKE_CUDA_COMPILER_VERSION} which is unsupported."
       "Please use CUDA toolkit version 9.0 or newer.")
+  endif()
+  if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(_remora_cmake_cuda_archs "${CMAKE_CUDA_ARCHITECTURES}")
+    remora_normalize_cuda_arch_list(_remora_cmake_cuda_archs _remora_cmake_cuda_archs_normalized)
+
+    foreach(_arch IN LISTS _remora_cmake_cuda_archs_normalized)
+      if(_arch LESS 60)
+        message(WARNING
+          "Your CMAKE_CUDA_ARCHITECTURES value is ${CMAKE_CUDA_ARCHITECTURES}, which includes "
+          "unsupported architecture ${_arch}."
+          "Please use AMReX_CUDA_ARCH 6.0 or newer.")
+        break()
+      endif()
+    endforeach()
   endif()
 endif()
 


### PR DESCRIPTION
Updates to fix cuda arch CI configuration
- CMake 3.20 changed top-level CUDA policy behavior: https://cmake.org/cmake/help/latest/policy/CMP0104.html
- CMake may auto-initialize CMAKE_CUDA_ARCHITECTURES for NVCC: https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html
- Unsupported defaults can leave CUDA_ARCHITECTURES empty and fail: https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html