### PR TITLE
Update tagging and blocking

### DIFF
--- a/Source/Initialization/REMORA_make_new_level.cpp
+++ b/Source/Initialization/REMORA_make_new_level.cpp
@@ -1024,7 +1024,7 @@ REMORA::fill_3d_masks (int lev)
         Array4<const Real> const& mskr = vec_mskr[lev]->const_array(mfi);
         Array4<      Real> const& mskr3d = vec_mskr3d[lev]->array(mfi);
 
-        Box bx = mfi.tilebox(); bx.grow(IntVect(1,1,0)); bx.makeSlab(2,0);
+        Box bx = mfi.tilebox(); bx.grow(IntVect(1,1,0));
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {

--- a/Source/REMORA.cpp
+++ b/Source/REMORA.cpp
@@ -88,6 +88,18 @@ REMORA::REMORA ()
 
     ReadParameters();
 
+    // Blocking factor in z set to very large value to be > nz
+    // This guarantees that there will be no domain decomposition in the z-direction
+    // We have to set this by hand here because setting it in the input file will
+    // cause checks in the AmrCore constructor to fail.
+    Vector<IntVect> blocking_factor_vec = Vector<IntVect>();
+    blocking_factor_vec.resize(max_level+1);
+    for (int lev = 0; lev <= max_level; ++lev) {
+        blocking_factor_vec[lev] = blockingFactor(lev);
+        blocking_factor_vec[lev][2] = 4096;
+    }
+    SetBlockingFactor(blocking_factor_vec);
+
     const std::string& pv3d = "plot_vars_3d"; set3DPlotVariables(pv3d);
     const std::string& pv2d = "plot_vars_2d"; set2DPlotVariables(pv2d);
 

--- a/Source/REMORA_Tagging.cpp
+++ b/Source/REMORA_Tagging.cpp
@@ -119,6 +119,31 @@ REMORA::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
 
         ref_tags[j](tags,mf.get(),clearval,tagval,time,levc,geom[levc]);
     }
+
+    // Promote any tagged cell to a full local z-column.
+    for (MFIter mfi(tags, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.validbox();
+        auto const& tag = tags.array(mfi);
+
+        const int klo = bx.smallEnd(2);
+        const int khi = bx.bigEnd(2);
+
+        amrex::ParallelFor(makeSlab(bx, 2, 0),
+        [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        {
+            bool refine_col = false;
+            for (int k = klo; k <= khi; ++k) {
+                refine_col = refine_col || (tag(i,j,k) != TagBox::CLEAR);
+            }
+
+            if (refine_col) {
+                for (int k = klo; k <= khi; ++k) {
+                    tag(i,j,k) = TagBox::SET;
+                }
+            }
+        });
+    }
 }
 
 /**
@@ -132,7 +157,6 @@ REMORA::refinement_criteria_setup ()
         ParmParse pp(pp_prefix);
         Vector<std::string> refinement_indicators;
         pp.queryarr("refinement_indicators",refinement_indicators,0,pp.countval("refinement_indicators"));
-
         for (int i=0; i<refinement_indicators.size(); ++i)
         {
             std::string ref_prefix = pp_prefix + "." + refinement_indicators[i];
@@ -381,10 +405,19 @@ REMORA::refinement_criteria_setup ()
                 Abort(std::string("Unrecognized refinement indicator for " + refinement_indicators[i]).c_str());
             }
         } // loop over criteria
-        // Untag anywhere we have masks
-        AMRErrorTagInfo info;
-        info.SetDerefine(1);
-        Real value = Real(0.5);
-        ref_tags.push_back(AMRErrorTag(value,AMRErrorTag::LESS,"mask",info));
+        {
+            // Untag anywhere we have masks
+            AMRErrorTagInfo info;
+            info.SetDerefine(1);
+            Real value = Real(0.5);
+            ref_tags.push_back(AMRErrorTag(value,AMRErrorTag::LESS,"mask",info));
+        }
+        {
+            // Also untag at mask-water boundaries
+            AMRErrorTagInfo info;
+            info.SetDerefine(1);
+            Real value = Real(0.5);
+            ref_tags.push_back(AMRErrorTag(value,AMRErrorTag::GRAD,"mask",info));
+        }
     } // if max_level > 0
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -39,7 +39,10 @@ void add_par () {
     int blocking_factor = 1;
     pp.queryAdd("blocking_factor",blocking_factor);
 
-    pp.add("n_error_buf",0);
+    // Default error buf of 0, user can override. Note that the whole column will be tagged
+    // if any one cell is tagged, even if n_error_buf_z = 0
+    int n_error_buf = 0;
+    pp.queryAdd("n_error_buf",n_error_buf);
 
     // Inject variables into ParmParse database with the prefixes AMReX expects
     // This allows a REMORA user to use the remora. prefix for some AMReX-specific options

--- a/Tests/test_files/Advection_ML/Advection_ML.i
+++ b/Tests/test_files/Advection_ML/Advection_ML.i
@@ -26,7 +26,6 @@ amr.v                = 1       # verbosity in Amr.cpp
 # REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed
 amr.ref_ratio_vect = 2 2 1
-amr.n_error_buf = 3 3
 amr.regrid_int=1
 
 # CHECKPOINT FILES


### PR DESCRIPTION
- Untag sea-land boundaries, so that we no longer erroneously tag regions when using gradient refinement conditions
- Tag full vertical column when any cell is tagged
- Blocking factor is set to large in z, bypassing AmrCore input checks
- Two prior points mean that there should no longer be domain decomposition in the z-direction on refined levels
- n_error_buf is now overridable by inputs; was previously set to 0