### PR TITLE
Validate river metadata sizes

### DIFF
--- a/Source/Initialization/REMORA_init_from_netcdf.cpp
+++ b/Source/Initialization/REMORA_init_from_netcdf.cpp
@@ -689,6 +689,16 @@ REMORA::init_riv_pos_from_netcdf (int lev)
     read_vec_from_netcdf(lev, nc_riv_file, river_y_name, river_pos_y);
     read_vec_from_netcdf(lev, nc_riv_file, river_dir_name, river_direction_tmp);
 
+    if (river_pos_x.empty() ||
+        river_pos_y.size() != river_pos_x.size() ||
+        river_direction_tmp.size() != river_pos_x.size())
+    {
+        amrex::Abort("River metadata arrays must be nonempty and have matching lengths: " +
+                     river_x_name + "=" + std::to_string(river_pos_x.size()) + ", " +
+                     river_y_name + "=" + std::to_string(river_pos_y.size()) + ", " +
+                     river_dir_name + "=" + std::to_string(river_direction_tmp.size()));
+    }
+
     int nriv = river_pos_x.size();
     amrex::Gpu::DeviceVector<int> xpos_d(nriv);
     amrex::Gpu::DeviceVector<int> ypos_d(nriv);


### PR DESCRIPTION
# Validate river metadata array lengths before copying

## Summary

Add an always-on validation check for river position and direction metadata read from NetCDF before REMORA allocates/copies river-position arrays.

## Problem

`init_riv_pos_from_netcdf()` reads three river metadata arrays:

- `river_Xposition`
- `river_Eposition`
- `river_direction`

The previous code set `nriv` from `river_Xposition.size()` and then indexed/copied all three arrays using that count. If the NetCDF file had inconsistent metadata lengths, REMORA could read past the end of the shorter host vector before the data was copied to device storage.

## Changes

- Require the river metadata arrays to be nonempty.
- Require `river_Xposition`, `river_Eposition`, and `river_direction` to have matching lengths.
- Abort with the three observed sizes before any allocation, refinement remapping, or host/device copy occurs.

## Verification

- Configured a PNetCDF+MPI library-only build:

```sh
cmake -S . -B /tmp/remora-f006-pnetcdf-mpi \
  -DREMORA_ENABLE_PNETCDF=ON \
  -DREMORA_ENABLE_MPI=ON \
  -DREMORA_BUILD_LIBRARY_ONLY=ON \
  -DREMORA_BUILD_EXECUTABLES=OFF
```

- Built the PNetCDF+MPI library target:

```sh
cmake --build /tmp/remora-f006-pnetcdf-mpi --target remora_srclib --parallel 2
```

This completed successfully and compiled `Source/Initialization/REMORA_init_from_netcdf.cpp`.

## Notes

An initial PNetCDF configure without `REMORA_ENABLE_MPI=ON` generated, but the build failed in PNetCDF headers because `mpi.h` was unavailable on that non-MPI compile path.
