### PR TITLE
Gate remora_exec on REMORA_BUILD_EXECUTABLES

### DIFF
--- a/Exec/CMakeLists.txt
+++ b/Exec/CMakeLists.txt
@@ -9,7 +9,7 @@ include(${PROJECT_SOURCE_DIR}/CMake/BuildREMORAExe.cmake)
 
 build_remora_lib(${remora_lib_name})
 
-if(NOT REMORA_BUILD_LIBRARY_ONLY)
+if(REMORA_BUILD_EXECUTABLES AND NOT REMORA_BUILD_LIBRARY_ONLY)
   set(remora_exe_name remora_exec)
   add_executable(${remora_exe_name} "")
   target_sources(${remora_exe_name}
@@ -19,4 +19,4 @@ if(NOT REMORA_BUILD_LIBRARY_ONLY)
   target_include_directories(${remora_exe_name} PRIVATE ${PROJECT_SOURCE_DIR}/Exec)
   build_remora_exe(${remora_exe_name})
 
-endif() # NOT REMORA_BUILD_LIBRARY_ONLY
+endif() # REMORA_BUILD_EXECUTABLES AND NOT REMORA_BUILD_LIBRARY_ONLY


### PR DESCRIPTION
# Gate remora_exec on REMORA_BUILD_EXECUTABLES

## Summary

Make the `remora_exec` CMake target follow the public `REMORA_BUILD_EXECUTABLES` option.

## Problem

`REMORA_BUILD_EXECUTABLES` controls whether executable-specific source files, including `Source/main.cpp`, are added to `remora_srclib`. However, `Exec/CMakeLists.txt` still created `remora_exec` unless the separate `REMORA_BUILD_LIBRARY_ONLY` variable was set.

That meant configurations such as:

```sh
cmake -S . -B build -DREMORA_BUILD_EXECUTABLES=OFF
```

could still generate a `remora_exec` target without the `main()` source needed to link it.

This is especially relevant for subproject/superbuild use, where `REMORA_BUILD_EXECUTABLES` defaults to `OFF`.

## Changes

- Create `remora_exec` only when `REMORA_BUILD_EXECUTABLES` is enabled.
- Preserve the existing `REMORA_BUILD_LIBRARY_ONLY` guard.

## Verification

- Configured with executable builds disabled:

```sh
cmake -S . -B /tmp/remora-f001-noexe -DREMORA_BUILD_EXECUTABLES=OFF
```

- Confirmed the generated build tree contains no `remora_exec` target:

```sh
rg -n "remora_exec" /tmp/remora-f001-noexe/Makefile /tmp/remora-f001-noexe/Exec /tmp/remora-f001-noexe/CMakeFiles
```

- Configured with default options:

```sh
cmake -S . -B /tmp/remora-f001-default
```

- Confirmed the default generated build tree still contains `remora_exec`.
